### PR TITLE
Merged to new version.

### DIFF
--- a/src/DotnetSpider.Core/Common/BloomFilter.cs
+++ b/src/DotnetSpider.Core/Common/BloomFilter.cs
@@ -2,471 +2,492 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 
 namespace DotnetSpider.Core.Common
 {
-	public class BloomFilter
-	{
-		private readonly BitArray _bitset;
-		private readonly int _bitSetSize;
-		private readonly double _bitsPerElement;
-		private readonly int _expectedNumberOfFilterElements; // expected (maximum) number of elements to be added
-		private int _numberOfAddedElements; // number of elements actually added to the Bloom filter
-		private readonly int _k; // number of hash functions
+    public class BloomFilter
+    {
+        private readonly BitArray _bitset;
+        private readonly int _bitSetSize;
+        private readonly double _bitsPerElement;
+        private readonly int _expectedNumberOfFilterElements; // expected (maximum) number of elements to be added
+        private int _numberOfAddedElements; // number of elements actually added to the Bloom filter
+        private readonly int _k; // number of hash functions
 
-		static readonly Encoding Charset = Encoding.UTF8; // encoding used for storing hash values as strings
+        static readonly Encoding Charset = Encoding.UTF8; // encoding used for storing hash values as strings
 
-		/// <summary>
-		/// The digest method is reused between instances
-		/// </summary>
-		/// <remarks>MD5 gives good enough accuracy in most circumstances. Change to SHA1 if it's needed</remarks>
-		static readonly KeyedHashAlgorithm DigestFunction = new HMACSHA1();
+        /// <summary>
+        /// The digest method is reused between instances
+        /// </summary>
+        /// <remarks>MD5 gives good enough accuracy in most circumstances. Change to SHA1 if it's needed</remarks>
+        static readonly KeyedHashAlgorithm DigestFunction = new HMACSHA1();
 
-		/// <summary>
-		/// Constructs an empty Bloom filter. The total length of the Bloom filter will be
-		/// c*n.
-		/// </summary>
-		/// <param name="c">is the number of bits used per element.</param>
-		/// <param name="n">is the expected number of elements the filter will contain.</param>
-		/// <param name="k">is the number of hash functions used.</param>
-		public BloomFilter(double c, int n, int k)
-		{
-			_expectedNumberOfFilterElements = n;
-			_k = k;
-			_bitsPerElement = c;
-			_bitSetSize = (int)Math.Ceiling(c * n);
-			_numberOfAddedElements = 0;
-			_bitset = new BitArray(_bitSetSize);
-		}
+        /// <summary>
+        /// Constructs an empty Bloom filter. The total length of the Bloom filter will be
+        /// c*n.
+        /// </summary>
+        /// <param name="c">is the number of bits used per element.</param>
+        /// <param name="n">is the expected number of elements the filter will contain.</param>
+        /// <param name="k">is the number of hash functions used.</param>
+        public BloomFilter(double c, int n, int k)
+        {
+            _expectedNumberOfFilterElements = n;
+            _k = k;
+            _bitsPerElement = c;
+            _bitSetSize = (int)Math.Ceiling(c * n);
+            _numberOfAddedElements = 0;
+            _bitset = new BitArray(_bitSetSize);
+        }
 
-		/// <summary>
-		/// Constructs an empty Bloom filter. The optimal number of hash functions (k) is estimated from the total size of the Bloom
-		/// and the number of expected elements.
-		/// </summary>
-		/// <param name="bitSetSize">defines how many bits should be used in total for the filter.</param>
-		/// <param name="expectedNumberOElements">defines the maximum number of elements the filter is expected to contain.</param>
-		public BloomFilter(int bitSetSize, int expectedNumberOElements)
-			: this(
-				bitSetSize / (double)expectedNumberOElements,
-				expectedNumberOElements,
-				(int)Math.Round((bitSetSize / (double)expectedNumberOElements) * Math.Log(2.0))
-			  )
-		{ }
+        /// <summary>
+        /// Constructs an empty Bloom filter. The optimal number of hash functions (k) is estimated from the total size of the Bloom
+        /// and the number of expected elements.
+        /// </summary>
+        /// <param name="bitSetSize">defines how many bits should be used in total for the filter.</param>
+        /// <param name="expectedNumberOElements">defines the maximum number of elements the filter is expected to contain.</param>
+        public BloomFilter(int bitSetSize, int expectedNumberOElements)
+            : this(
+                bitSetSize / (double)expectedNumberOElements,
+                expectedNumberOElements,
+                (int)Math.Round((bitSetSize / (double)expectedNumberOElements) * Math.Log(2.0))
+              )
+        { }
 
-		/// <summary>
-		/// Constructs an empty Bloom filter with a given false positive probability. The number of bits per
-		/// element and the number of hash functions is estimated
-		/// to match the false positive probability.
-		/// </summary>
-		/// <param name="falsePositiveProbability">is the desired false positive probability.</param>
-		/// <param name="expectedNumberOfElements">is the expected number of elements in the Bloom filter.</param>
-		public BloomFilter(double falsePositiveProbability, int expectedNumberOfElements)
-			: this(
-				Math.Ceiling(-(Math.Log(falsePositiveProbability) / Math.Log(2))) / Math.Log(2), // c = k / ln(2)
-				expectedNumberOfElements,
-				(int)Math.Ceiling(-(Math.Log(falsePositiveProbability) / Math.Log(2))) // k = ceil(-log_2(false prob.))
-			  )
-		{ }
+        /// <summary>
+        /// Constructs an empty Bloom filter with a given false positive probability. The number of bits per
+        /// element and the number of hash functions is estimated
+        /// to match the false positive probability.
+        /// </summary>
+        /// <param name="falsePositiveProbability">is the desired false positive probability.</param>
+        /// <param name="expectedNumberOfElements">is the expected number of elements in the Bloom filter.</param>
+        public BloomFilter(double falsePositiveProbability, int expectedNumberOfElements)
+            : this(
+                Math.Ceiling(-(Math.Log(falsePositiveProbability) / Math.Log(2))) / Math.Log(2), // c = k / ln(2)
+                expectedNumberOfElements,
+                (int)Math.Ceiling(-(Math.Log(falsePositiveProbability) / Math.Log(2))) // k = ceil(-log_2(false prob.))
+              )
+        { }
 
-		/// <summary>
-		/// Construct a new Bloom filter based on existing Bloom filter data.
-		/// </summary>
-		/// <param name="bitSetSize">defines how many bits should be used for the filter.</param>
-		/// <param name="expectedNumberOfFilterElements">defines the maximum number of elements the filter is expected to contain.</param>
-		/// <param name="actualNumberOfFilterElements">specifies how many elements have been inserted into the <code>filterData</code> BitArray.</param>
-		/// <param name="filterData">a BitArray representing an existing Bloom filter.</param>
-		public BloomFilter(int bitSetSize, int expectedNumberOfFilterElements, int actualNumberOfFilterElements, BitArray filterData)
-			: this(bitSetSize, expectedNumberOfFilterElements)
-		{
-			_bitset = filterData;
-			_numberOfAddedElements = actualNumberOfFilterElements;
-		}
+        /// <summary>
+        /// Construct a new Bloom filter based on existing Bloom filter data.
+        /// </summary>
+        /// <param name="bitSetSize">defines how many bits should be used for the filter.</param>
+        /// <param name="expectedNumberOfFilterElements">defines the maximum number of elements the filter is expected to contain.</param>
+        /// <param name="actualNumberOfFilterElements">specifies how many elements have been inserted into the <code>filterData</code> BitArray.</param>
+        /// <param name="filterData">a BitArray representing an existing Bloom filter.</param>
+        public BloomFilter(int bitSetSize, int expectedNumberOfFilterElements, int actualNumberOfFilterElements, BitArray filterData)
+            : this(bitSetSize, expectedNumberOfFilterElements)
+        {
+            _bitset = filterData;
+            _numberOfAddedElements = actualNumberOfFilterElements;
+        }
 
-		/// <summary>
-		/// Generates a digest based on the contents of a string.
-		/// </summary>
-		/// <param name="val">specifies the input data.</param>
-		/// <param name="charset">specifies the encoding of the input data.</param>
-		/// <returns>digest as long.</returns>
-		public static int CreateHash(string val, Encoding charset)
-		{
-			return CreateHash(charset.GetBytes(val));
-		}
+        /// <summary>
+        /// Generates a digest based on the contents of a string.
+        /// </summary>
+        /// <param name="val">specifies the input data.</param>
+        /// <param name="charset">specifies the encoding of the input data.</param>
+        /// <returns>digest as long.</returns>
+        public static int CreateHash(string val, Encoding charset)
+        {
+            return CreateHash(charset.GetBytes(val));
+        }
 
-		/// <summary>
-		/// Generates a digest based on the contents of a string.
-		/// </summary>
-		/// <param name="val">specifies the input data. The encoding is expected to be UTF-8.</param>
-		/// <returns>digest as long.</returns>
-		public static int CreateHash(string val)
-		{
-			return CreateHash(val, Charset);
-		}
+        /// <summary>
+        /// Generates a digest based on the contents of a string.
+        /// </summary>
+        /// <param name="val">specifies the input data. The encoding is expected to be UTF-8.</param>
+        /// <returns>digest as long.</returns>
+        public static int CreateHash(string val)
+        {
+            return CreateHash(val, Charset);
+        }
 
-		/// <summary>
-		/// Generates a digest based on the contents of an array of bytes.
-		/// </summary>
-		/// <param name="data">specifies input data.</param>
-		/// <returns>digest as long.</returns>
-		public static int CreateHash(byte[] data)
-		{
-			return CreateHashes(data, 1)[0];
-		}
+        /// <summary>
+        /// Generates a digest based on the contents of an array of bytes.
+        /// </summary>
+        /// <param name="data">specifies input data.</param>
+        /// <returns>digest as long.</returns>
+        public static int CreateHash(byte[] data)
+        {
+            return CreateHashes(data, 1)[0];
+        }
 
-		/// <summary>
-		/// Generates digests based on the contents of an array of bytes and splits the result into 4-byte int's and store them in an array. The
-		/// digest function is called until the required number of int's are produced. For each call to digest a salt
-		/// is prepended to the data. The salt is increased by 1 for each call.
-		/// </summary>
-		/// <param name="data">specifies input data</param>
-		/// <param name="hashes">number of hashes/int's to produce</param>
-		/// <returns>array of int-sized hashes</returns>
-		public static int[] CreateHashes(byte[] data, int hashes)
-		{
-			int[] result = new int[hashes];
+        /// <summary>
+        /// Generates digests based on the contents of an array of bytes and splits the result into 4-byte int's and store them in an array. The
+        /// digest function is called until the required number of int's are produced. For each call to digest a salt
+        /// is prepended to the data. The salt is increased by 1 for each call.
+        /// </summary>
+        /// <param name="data">specifies input data</param>
+        /// <param name="hashes">number of hashes/int's to produce</param>
+        /// <returns>array of int-sized hashes</returns>
+        public static int[] CreateHashes(byte[] data, int hashes)
+        {
+            int[] result = new int[hashes];
 
-			int k = 0;
-			byte[] salt = new byte[1];
-			while (k < hashes)
-			{
-				byte[] digest;
-				lock (DigestFunction)
-				{
-					DigestFunction.Key = salt;
-					salt[0]++;
-					digest = DigestFunction.ComputeHash(data);
-				}
+            int k = 0;
+            byte[] salt = new byte[1];
+            while (k < hashes)
+            {
+                byte[] digest;
+                lock (DigestFunction)
+                {
+                    DigestFunction.Key = salt;
+                    salt[0]++;
+                    digest = DigestFunction.ComputeHash(data);
+                }
 
-				for (int i = 0; i < digest.Length / 4 && k < hashes; i++)
-				{
-					int h = 0;
-					for (int j = (i * 4); j < (i * 4) + 4; j++)
-					{
-						h <<= 8;
-						h |= digest[j] & 0xFF;
-					}
-					result[k] = h;
-					k++;
-				}
-			}
-			return result;
-		}
+                for (int i = 0; i < digest.Length / 4 && k < hashes; i++)
+                {
+                    int h = 0;
+                    for (int j = (i * 4); j < (i * 4) + 4; j++)
+                    {
+                        h <<= 8;
+                        h |= digest[j] & 0xFF;
+                    }
+                    result[k] = h;
+                    k++;
+                }
+            }
+            return result;
+        }
 
-		/// <summary>
-		/// Compares the contents of two instances to see if they are equal.
-		/// </summary>
-		/// <param name="obj">is the object to compare to.</param>
-		/// <returns>True if the contents of the objects are equal.</returns>
-		public override bool Equals(object obj)
-		{
-			if (obj == null)
-			{
-				return false;
-			}
-			if (GetType() != obj.GetType())
-			{
-				return false;
-			}
-			BloomFilter other = (BloomFilter)obj;
-			if (_expectedNumberOfFilterElements != other._expectedNumberOfFilterElements)
-			{
-				return false;
-			}
-			if (_k != other._k)
-			{
-				return false;
-			}
-			if (_bitSetSize != other._bitSetSize)
-			{
-				return false;
-			}
-			if (_bitset != other._bitset && (_bitset == null || !ObjectUtils.Equals(_bitset, other._bitset)))
-			{
-				return false;
-			}
-			return true;
-		}
+        /// <summary>
+        /// Compares the contents of two instances to see if they are equal.
+        /// </summary>
+        /// <param name="obj">is the object to compare to.</param>
+        /// <returns>True if the contents of the objects are equal.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+            if (GetType() != obj.GetType())
+            {
+                return false;
+            }
+            BloomFilter other = (BloomFilter)obj;
+            if (_expectedNumberOfFilterElements != other._expectedNumberOfFilterElements)
+            {
+                return false;
+            }
+            if (_k != other._k)
+            {
+                return false;
+            }
+            if (_bitSetSize != other._bitSetSize)
+            {
+                return false;
+            }
+            if (_bitset != other._bitset && (_bitset == null || !ObjectUtils.Equals(_bitset, other._bitset)))
+            {
+                return false;
+            }
+            return true;
+        }
 
-		/// <summary>
-		/// Calculates a hash code for this class.
-		/// <remarks>performance concerns : note that we read all the bits of bitset to compute the hash</remarks>
-		/// <returns>hash code representing the contents of an instance of this class.</returns>
-		/// </summary>
-		public override int GetHashCode()
-		{
-			int hash = 7;
-			hash = 61 * hash + (_bitset != null ? ObjectUtils.HashBytes(_bitset) : 0);
-			hash = 61 * hash + _expectedNumberOfFilterElements;
-			hash = 61 * hash + _bitSetSize;
-			hash = 61 * hash + _k;
-			return hash;
-		}
-
-
-		/// <summary>
-		/// Calculates the expected probability of false positives based on
-		/// the number of expected filter elements and the size of the Bloom filter.
-		/// <br /><br />
-		/// The value returned by this method is the <i>expected</i> rate of false
-		/// positives, assuming the number of inserted elements equals the number of
-		/// expected elements. If the number of elements in the Bloom filter is less
-		/// than the expected value, the true probability of false positives will be lower.
-		/// </summary>
-		/// <returns>expected probability of false positives.</returns>
-		public double ExpectedFalsePositiveProbability()
-		{
-			return GetFalsePositiveProbability(_expectedNumberOfFilterElements);
-		}
-
-		/// <summary>
-		/// Calculate the probability of a false positive given the specified
-		/// number of inserted elements.
-		/// </summary>
-		/// <param name="numberOfElements">number of inserted elements.</param>
-		/// <returns>probability of a false positive.</returns>
-		public double GetFalsePositiveProbability(double numberOfElements)
-		{
-			// (1 - e^(-k * n / m)) ^ k
-			return Math.Pow((1 - Math.Exp(-_k * numberOfElements
-						/ _bitSetSize)), _k);
-
-		}
-
-		/// <summary>
-		/// Get the current probability of a false positive. The probability is calculated from
-		/// the size of the Bloom filter and the current number of elements added to it.
-		/// </summary>
-		/// <returns>probability of false positives.</returns>
-		public double GetFalsePositiveProbability()
-		{
-			return GetFalsePositiveProbability(_numberOfAddedElements);
-		}
+        /// <summary>
+        /// Calculates a hash code for this class.
+        /// <remarks>performance concerns : note that we read all the bits of bitset to compute the hash</remarks>
+        /// <returns>hash code representing the contents of an instance of this class.</returns>
+        /// </summary>
+        public override int GetHashCode()
+        {
+            int hash = 7;
+            hash = 61 * hash + (_bitset != null ? ObjectUtils.HashBytes(_bitset) : 0);
+            hash = 61 * hash + _expectedNumberOfFilterElements;
+            hash = 61 * hash + _bitSetSize;
+            hash = 61 * hash + _k;
+            return hash;
+        }
 
 
-		/// <summary>
-		/// Returns the value chosen for K.<br />
-		/// <br />
-		/// K is the optimal number of hash functions based on the size
-		/// of the Bloom filter and the expected number of inserted elements.
-		/// </summary>
-		/// <returns>optimal k.</returns>
-		public int GetK()
-		{
-			return _k;
-		}
+        /// <summary>
+        /// Calculates the expected probability of false positives based on
+        /// the number of expected filter elements and the size of the Bloom filter.
+        /// <br /><br />
+        /// The value returned by this method is the <i>expected</i> rate of false
+        /// positives, assuming the number of inserted elements equals the number of
+        /// expected elements. If the number of elements in the Bloom filter is less
+        /// than the expected value, the true probability of false positives will be lower.
+        /// </summary>
+        /// <returns>expected probability of false positives.</returns>
+        public double ExpectedFalsePositiveProbability()
+        {
+            return GetFalsePositiveProbability(_expectedNumberOfFilterElements);
+        }
 
-		/// <summary>
-		/// Sets all bits to false in the Bloom filter.
-		/// </summary>
-		public void Clear()
-		{
-			_bitset.SetAll(false);
-			_numberOfAddedElements = 0;
-		}
+        /// <summary>
+        /// Calculate the probability of a false positive given the specified
+        /// number of inserted elements.
+        /// </summary>
+        /// <param name="numberOfElements">number of inserted elements.</param>
+        /// <returns>probability of a false positive.</returns>
+        public double GetFalsePositiveProbability(double numberOfElements)
+        {
+            // (1 - e^(-k * n / m)) ^ k
+            return Math.Pow((1 - Math.Exp(-_k * numberOfElements
+                        / _bitSetSize)), _k);
 
-		/// <summary>
-		/// Adds an object to the Bloom filter. The output from the object's
-		/// ToString() method is used as input to the hash functions.
-		/// </summary>
-		/// <param name="element">is an element to register in the Bloom filter.</param>
-		public void Add(object element)
-		{
-			Add(Charset.GetBytes(element.ToString()));
-		}
+        }
 
-		/// <summary>
-		/// Adds an array of bytes to the Bloom filter.
-		/// </summary>
-		/// <param name="bytes">array of bytes to add to the Bloom filter.</param>
-		public void Add(byte[] bytes)
-		{
-			int[] hashes = CreateHashes(bytes, _k);
-			foreach (int hash in hashes)
-			{
-				_bitset.Set(Math.Abs(hash % _bitSetSize), true);
-			}
-			_numberOfAddedElements++;
-		}
+        /// <summary>
+        /// Get the current probability of a false positive. The probability is calculated from
+        /// the size of the Bloom filter and the current number of elements added to it.
+        /// </summary>
+        /// <returns>probability of false positives.</returns>
+        public double GetFalsePositiveProbability()
+        {
+            return GetFalsePositiveProbability(_numberOfAddedElements);
+        }
 
-		/// <summary>
-		/// Adds all elements from a Collection to the Bloom filter.
-		/// </summary>
-		/// <param name="c">Collection of elements.</param>
-		public void AddAll(IEnumerable<object> c)
-		{
-			foreach (object element in c)
-			{
-				Add(element);
-			}
-		}
 
-		/// <summary>
-		/// Adds all elements from a Collection to the Bloom filter.
-		/// </summary>
-		/// <param name="c">Collection of elements.</param>
-		public void AddAll(IEnumerable<byte[]> c)
-		{
-			foreach (byte[] byteArray in c)
-			{
-				Add(byteArray);
-			}
-		}
+        /// <summary>
+        /// Returns the value chosen for K.<br />
+        /// <br />
+        /// K is the optimal number of hash functions based on the size
+        /// of the Bloom filter and the expected number of inserted elements.
+        /// </summary>
+        /// <returns>optimal k.</returns>
+        public int GetK()
+        {
+            return _k;
+        }
 
-		/// <summary>
-		/// Returns true if the element could have been inserted into the Bloom filter.
-		/// Use getFalsePositiveProbability() to calculate the probability of this
-		/// being correct.
-		/// </summary>
-		/// <param name="element">element to check.</param>
-		/// <returns>true if the element could have been inserted into the Bloom filter.</returns>
-		public bool Contains(object element)
-		{
-			return Contains(Charset.GetBytes(element.ToString()));
-		}
+        /// <summary>
+        /// Sets all bits to false in the Bloom filter.
+        /// </summary>
+        public void Clear()
+        {
+            _bitset.SetAll(false);
+            _numberOfAddedElements = 0;
+        }
 
-		/// <summary>
-		/// Returns true if the array of bytes could have been inserted into the Bloom filter.
-		/// Use getFalsePositiveProbability() to calculate the probability of this
-		/// being correct.
-		/// </summary>
-		/// <param name="bytes">array of bytes to check.</param>
-		/// <returns>true if the array could have been inserted into the Bloom filter.</returns>
-		public bool Contains(byte[] bytes)
-		{
-			int[] hashes = CreateHashes(bytes, _k);
-			return hashes.All(hash => _bitset.Get(Math.Abs(hash % _bitSetSize)));
-		}
+        /// <summary>
+        /// Adds an object to the Bloom filter. The output from the object's
+        /// ToString() method is used as input to the hash functions.
+        /// </summary>
+        /// <param name="element">is an element to register in the Bloom filter.</param>
+        public void Add(object element)
+        {
+            Add(Charset.GetBytes(element.ToString()));
+        }
 
-		/// <summary>
-		/// Returns true if all the elements of a Collection could have been inserted
-		/// into the Bloom filter. Use getFalsePositiveProbability() to calculate the
-		/// probability of this being correct.
-		/// </summary>
-		/// <param name="c">elements to check.</param>
-		/// <returns>true if all the elements in c could have been inserted into the Bloom filter.</returns>
-		public bool ContainsAll(IEnumerable<object> c)
-		{
-			return c.All(Contains);
-		}
+        /// <summary>
+        /// Adds an array of bytes to the Bloom filter.
+        /// </summary>
+        /// <param name="bytes">array of bytes to add to the Bloom filter.</param>
+        public void Add(byte[] bytes)
+        {
+            int[] hashes = CreateHashes(bytes, _k);
+            foreach (int hash in hashes)
+            {
+                _bitset.Set(Math.Abs(hash % _bitSetSize), true);
+            }
+            _numberOfAddedElements++;
+        }
 
-		/// <summary>
-		/// Read a single bit from the Bloom filter.
-		/// </summary>
-		/// <param name="bit">the bit to read.</param>
-		/// <returns>true if the bit is set, false if it is not.</returns>
-		public bool GetBit(int bit)
-		{
-			return _bitset.Get(bit);
-		}
+        /// <summary>
+        /// Adds all elements from a Collection to the Bloom filter.
+        /// </summary>
+        /// <param name="c">Collection of elements.</param>
+        public void AddAll(IEnumerable<object> c)
+        {
+            foreach (object element in c)
+            {
+                Add(element);
+            }
+        }
 
-		/// <summary>
-		/// Set a single bit in the Bloom filter.
-		/// </summary>
-		/// <param name="bit">is the bit to set.</param>
-		/// <param name="value">If true, the bit is set. If false, the bit is cleared.</param>
-		public void SetBit(int bit, bool value)
-		{
-			_bitset.Set(bit, value);
-		}
+        /// <summary>
+        /// Adds all elements from a Collection to the Bloom filter.
+        /// </summary>
+        /// <param name="c">Collection of elements.</param>
+        public void AddAll(IEnumerable<byte[]> c)
+        {
+            foreach (byte[] byteArray in c)
+            {
+                Add(byteArray);
+            }
+        }
 
-		/// <summary>
-		/// Return the bit set used to store the Bloom filter.
-		/// </summary>
-		/// <returns>bit set representing the Bloom filter.</returns>
-		public BitArray GetBitSet()
-		{
-			return _bitset;
-		}
+        /// <summary>
+        /// Returns true if the element could have been inserted into the Bloom filter.
+        /// Use getFalsePositiveProbability() to calculate the probability of this
+        /// being correct.
+        /// </summary>
+        /// <param name="element">element to check.</param>
+        /// <returns>true if the element could have been inserted into the Bloom filter.</returns>
+        public bool Contains(object element)
+        {
+            return Contains(Charset.GetBytes(element.ToString()));
+        }
 
-		/// <summary>
-		/// Returns the number of bits in the Bloom filter. Use count() to retrieve
-		/// the number of inserted elements.
-		/// </summary>
-		/// <returns>the size of the bitset used by the Bloom filter.</returns>
-		public int Size()
-		{
-			return _bitSetSize;
-		}
+        /// <summary>
+        /// Returns true if the array of bytes could have been inserted into the Bloom filter.
+        /// Use getFalsePositiveProbability() to calculate the probability of this
+        /// being correct.
+        /// </summary>
+        /// <param name="bytes">array of bytes to check.</param>
+        /// <returns>true if the array could have been inserted into the Bloom filter.</returns>
+        public bool Contains(byte[] bytes)
+        {
+            int[] hashes = CreateHashes(bytes, _k);
+            return hashes.All(hash => _bitset.Get(Math.Abs(hash % _bitSetSize)));
+        }
 
-		/// <summary>
-		/// Returns the number of elements added to the Bloom filter after it
-		/// was constructed or after clear() was called.
-		/// </summary>
-		/// <returns>number of elements added to the Bloom filter.</returns>
-		public int Count()
-		{
-			return _numberOfAddedElements;
-		}
+        /// <summary>
+        /// Returns true if all the elements of a Collection could have been inserted
+        /// into the Bloom filter. Use getFalsePositiveProbability() to calculate the
+        /// probability of this being correct.
+        /// </summary>
+        /// <param name="c">elements to check.</param>
+        /// <returns>true if all the elements in c could have been inserted into the Bloom filter.</returns>
+        public bool ContainsAll(IEnumerable<object> c)
+        {
+            return c.All(Contains);
+        }
 
-		/// <summary>
-		/// Returns the expected number of elements to be inserted into the filter.
-		/// This value is the same value as the one passed to the constructor.
-		/// </summary>
-		/// <returns>expected number of elements.</returns>
-		public int GetExpectedNumberOfElements()
-		{
-			return _expectedNumberOfFilterElements;
-		}
+        /// <summary>
+        /// Read a single bit from the Bloom filter.
+        /// </summary>
+        /// <param name="bit">the bit to read.</param>
+        /// <returns>true if the bit is set, false if it is not.</returns>
+        public bool GetBit(int bit)
+        {
+            return _bitset.Get(bit);
+        }
 
-		/// <summary>
-		/// Get expected number of bits per element when the Bloom filter is full. This value is set by the constructor
-		/// when the Bloom filter is created. See also getBitsPerElement().
-		/// </summary>
-		/// <returns>expected number of bits per element.</returns>
-		public double GetExpectedBitsPerElement()
-		{
-			return _bitsPerElement;
-		}
+        /// <summary>
+        /// Set a single bit in the Bloom filter.
+        /// </summary>
+        /// <param name="bit">is the bit to set.</param>
+        /// <param name="value">If true, the bit is set. If false, the bit is cleared.</param>
+        public void SetBit(int bit, bool value)
+        {
+            _bitset.Set(bit, value);
+        }
 
-		/// <summary>
-		/// Get actual number of bits per element based on the number of elements that have currently been inserted and the length
-		/// of the Bloom filter. See also getExpectedBitsPerElement().
-		/// </summary>
-		/// <returns>number of bits per element.</returns>
-		public double GetBitsPerElement()
-		{
-			return _bitSetSize / (double)_numberOfAddedElements;
-		}
-	}
+        /// <summary>
+        /// Return the bit set used to store the Bloom filter.
+        /// </summary>
+        /// <returns>bit set representing the Bloom filter.</returns>
+        public BitArray GetBitSet()
+        {
+            return _bitset;
+        }
 
-	public static class ObjectUtils
-	{
-		/// <summary>
-		/// Generate a hash value from an array of bits
-		/// </summary>
-		/// <remarks>voir http://blog.roblevine.co.uk for comparison of hash algorithm implementations</remarks>
-		/// <param name="data">array of bits to hash</param>
-		/// <returns></returns>
-		public static int HashBytes(BitArray data)
-		{
-			// convert bit array to integer array
-			int[] intArray = new int[(data.Length + 31) / 32];
-			data.CopyTo(intArray, 0);
-			// compute the hash from integer array values
-			unchecked
-			{
-				return intArray.Aggregate(23, (current, n) => current * 37 + n);
-			}
-		}
+        /// <summary>
+        /// Returns the number of bits in the Bloom filter. Use count() to retrieve
+        /// the number of inserted elements.
+        /// </summary>
+        /// <returns>the size of the bitset used by the Bloom filter.</returns>
+        public int Size()
+        {
+            return _bitSetSize;
+        }
 
-		/// <summary>
-		/// Check if two arrays of bits are equals
-		/// Returns true if every bit of this first array is equal to the corresponding bit of the second, false otherwise
-		/// </summary>
-		public static bool Equals(BitArray a, BitArray b)
-		{
-			if (a.Length != b.Length) return false;
+        /// <summary>
+        /// Returns the number of elements added to the Bloom filter after it
+        /// was constructed or after clear() was called.
+        /// </summary>
+        /// <returns>number of elements added to the Bloom filter.</returns>
+        public int Count()
+        {
+            return _numberOfAddedElements;
+        }
 
-			var enumA = a.GetEnumerator();
-			var enumB = b.GetEnumerator();
+        /// <summary>
+        /// Returns the expected number of elements to be inserted into the filter.
+        /// This value is the same value as the one passed to the constructor.
+        /// </summary>
+        /// <returns>expected number of elements.</returns>
+        public int GetExpectedNumberOfElements()
+        {
+            return _expectedNumberOfFilterElements;
+        }
 
-			while (enumA.MoveNext() && enumB.MoveNext())
-			{
-				if ((bool)enumA.Current != (bool)enumB.Current) return false;
-			}
-			return true;
-		}
-	}
+        /// <summary>
+        /// Get expected number of bits per element when the Bloom filter is full. This value is set by the constructor
+        /// when the Bloom filter is created. See also getBitsPerElement().
+        /// </summary>
+        /// <returns>expected number of bits per element.</returns>
+        public double GetExpectedBitsPerElement()
+        {
+            return _bitsPerElement;
+        }
+
+        /// <summary>
+        /// Get actual number of bits per element based on the number of elements that have currently been inserted and the length
+        /// of the Bloom filter. See also getExpectedBitsPerElement().
+        /// </summary>
+        /// <returns>number of bits per element.</returns>
+        public double GetBitsPerElement()
+        {
+            return _bitSetSize / (double)_numberOfAddedElements;
+        }
+    }
+
+    public static class ObjectUtils
+    {
+        /// <summary>
+        /// Generate a hash value from an array of bits
+        /// </summary>
+        /// <remarks>voir http://blog.roblevine.co.uk for comparison of hash algorithm implementations</remarks>
+        /// <param name="data">array of bits to hash</param>
+        /// <returns></returns>
+        public static int HashBytes(BitArray data)
+        {
+            // convert bit array to integer array
+            int[] intArray = new int[(data.Length + 31) / 32];
+            data.CopyTo(intArray, 0);
+            // compute the hash from integer array values
+            unchecked
+            {
+                return intArray.Aggregate(23, (current, n) => current * 37 + n);
+            }
+        }
+
+        /// <summary>
+        /// Check if two arrays of bits are equals
+        /// Returns true if every bit of this first array is equal to the corresponding bit of the second, false otherwise
+        /// </summary>
+        public static bool Equals(BitArray a, BitArray b)
+        {
+            if (a.Length != b.Length) return false;
+
+            var enumA = a.GetEnumerator();
+            var enumB = b.GetEnumerator();
+
+            while (enumA.MoveNext() && enumB.MoveNext())
+            {
+                if ((bool)enumA.Current != (bool)enumB.Current) return false;
+            }
+            return true;
+        }
+    }
+
+    public static class CrossPlatformUtil
+    {
+        public static Type GetTypeCrossPlatform(this Type entityType)
+        {
+            return entityType;
+        }
+        public static Type GetTypeCrossPlatform(this TypeInfo entityType)
+        {
+            return entityType.AsType();
+        }
+        public static TypeInfo GetTypeInfoCrossPlatform(this Type entityType)
+        {
+            return entityType.GetTypeInfo();
+        }
+        public static TypeInfo GetTypeInfoCrossPlatform(this TypeInfo entityType)
+        {
+            return entityType;
+        }
+    }
 }

--- a/src/DotnetSpider.Core/Site.cs
+++ b/src/DotnetSpider.Core/Site.cs
@@ -109,6 +109,10 @@ namespace DotnetSpider.Core
 		public int CycleRetryTimes { get; set; } = 5;
 
 		public string Cookie { get; set; }
+        /// <summary>
+        /// Same content as Cookie, but this collection version can be used by webdrivers more handily.
+        /// </summary>
+        public Dictionary<string, string> Cookies { get; set; } = new Dictionary<string, string>();
 
 		/// <summary>
 		/// Set or Get up httpProxy for this site

--- a/src/DotnetSpider.Core/Spider.cs
+++ b/src/DotnetSpider.Core/Spider.cs
@@ -347,6 +347,7 @@ namespace DotnetSpider.Core
 		{
 			CheckIfRunning();
 			Downloader = downloader;
+            Downloader.Context = this;
 			return this;
 		}
 

--- a/src/DotnetSpider.Extension/Common/SelectorUtil.cs
+++ b/src/DotnetSpider.Extension/Common/SelectorUtil.cs
@@ -2,7 +2,16 @@
 using DotnetSpider.Core.Selector;
 using DotnetSpider.Extension.Model;
 using DotnetSpider.Extension.Model.Attribute;
-
+using DotnetSpider.Extension.Model.Formatter;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+#if !NET_CORE
+using System.Web;
+#else
+using System.Net;
+#endif
 namespace DotnetSpider.Extension.Common
 {
 	public class SelectorUtil
@@ -88,5 +97,111 @@ namespace DotnetSpider.Extension.Common
 			}
 			throw new SpiderException("Not support selector: " + selector);
 		}
-	}
+
+        /// <summary>
+        /// 如果找不到则不返回URL, 不然返回的URL太多
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="page"></param>
+        /// <param name="targetUrlExtractInfos"></param>
+        internal static void ExtractLinks(ISelectable item, Page page, List<Processor.EntityProcessor.TargetUrlExtractorInfo> targetUrlExtractInfos)
+        {
+            if (targetUrlExtractInfos == null)
+            {
+                return;
+            }
+
+            foreach (var targetUrlExtractInfo in targetUrlExtractInfos)
+            {
+                var urlRegionSelector = targetUrlExtractInfo.Region;
+                var formatters = targetUrlExtractInfo.Formatters;
+                var urlPatterns = targetUrlExtractInfo.Patterns;
+                var extras = targetUrlExtractInfo.Extras;
+                var selectable = item ?? page.Selectable;
+
+                var links = urlRegionSelector == null ? selectable.Links().GetValues() : (selectable.SelectList(urlRegionSelector)).Links().GetValues();
+                if (links == null)
+                {
+                    return;
+                }
+
+                // check: 仔细考虑是放在前面, 还是在后面做 formatter, 我倾向于在前面. 对targetUrl做formatter则表示Start Url也应该是要符合这个规则的。
+                if (formatters != null && formatters.Count > 0)
+                {
+                    List<string> tmp = new List<string>();
+                    foreach (string link in links)
+                    {
+                        var url = new String(link.ToCharArray());
+                        foreach (Formatter f in formatters)
+                        {
+                            url = f.Formate(url);
+                        }
+                        tmp.Add(url);
+                    }
+                    links = tmp;
+                }
+
+                List<string> tmpLinks = new List<string>();
+                foreach (var link in links)
+                {
+#if !NET_CORE
+                    tmpLinks.Add(HttpUtility.HtmlDecode(HttpUtility.UrlDecode(link)));
+#else
+					tmpLinks.Add(WebUtility.HtmlDecode(WebUtility.UrlDecode(link)));
+#endif
+                }
+                links = tmpLinks;
+                var allExtras = new Dictionary<string, dynamic>();
+                foreach (var extra in page.Request.Extras.Union(extras))
+                {
+                    allExtras.Add(extra.Key, extra.Value);
+                }
+
+                if (urlPatterns == null || urlPatterns.Count == 0)
+                {
+                    //page.AddTargetRequests(links);
+                    foreach (var link in links)
+                    {
+                        page.AddTargetRequest(new Request(link, page.Request.NextDepth, allExtras));
+                    }
+                    return;
+                }
+
+                foreach (Regex targetUrlPattern in urlPatterns)
+                {
+                    foreach (string link in links)
+                    {
+                        if (targetUrlPattern.IsMatch(link))
+                        {
+                            page.AddTargetRequest(new Request(link, page.Request.NextDepth, allExtras));
+                        }
+                    }
+                }
+            }
+        }
+
+        public static void ExtractLinks(ISelectable item, Page page, List<TargetUrlExtractor> targetUrlExtractors)
+        {
+            ExtractLinks(item, page, _transform(targetUrlExtractors));
+        }
+        private static List<Processor.EntityProcessor.TargetUrlExtractorInfo> _transform(List<TargetUrlExtractor> targetUrlExtractors)
+        {
+            List<Processor.EntityProcessor.TargetUrlExtractorInfo> result = new List<Processor.EntityProcessor.TargetUrlExtractorInfo>();
+            if (targetUrlExtractors != null)
+            {
+                foreach (var targetUrlExtractor in targetUrlExtractors)
+                {
+                    result.Add(new Processor.EntityProcessor.TargetUrlExtractorInfo
+                    {
+                        Patterns = targetUrlExtractor.Patterns.Select(t => new Regex(t)).ToList(),
+                        Formatters = targetUrlExtractor.Formatters,
+                        Region = SelectorUtil.Parse(targetUrlExtractor.Region),
+                        Extras = targetUrlExtractor.Extras
+                    });
+                }
+            }
+            return result;
+        }
+
+    }
 }

--- a/src/DotnetSpider.Extension/Downloader/CookieInterceptor.cs
+++ b/src/DotnetSpider.Extension/Downloader/CookieInterceptor.cs
@@ -3,6 +3,7 @@ using NLog;
 using DotnetSpider.Core;
 using DotnetSpider.Core.Selector;
 using System.Collections.Generic;
+using OpenQA.Selenium.Support.UI;
 #if !NET_CORE
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -16,252 +17,271 @@ using OpenQA.Selenium.Remote;
 
 namespace DotnetSpider.Extension.Downloader
 {
-	public abstract class CookieInterceptor : Named
-	{
-		protected readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+    public abstract class CookieInterceptor : Named
+    {
+        protected readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-		public abstract Tuple<string, Dictionary<string, string>> GetCookie();
-	}
+        public abstract Tuple<string, Dictionary<string, string>> GetCookie();
+    }
 
 #if !NET_CORE
-	public abstract class WebDriverCookieInterceptor : CookieInterceptor
-	{
-		protected IWebElement FindElement(RemoteWebDriver webDriver, Selector element)
-		{
-			switch (element.Type)
-			{
+    public abstract class WebDriverCookieInterceptor : CookieInterceptor
+    {
+        protected IWebElement FindElement(RemoteWebDriver webDriver, Selector element, int waitTime = 0)
+        {
+            if (element.Type != SelectorType.XPath && element.Type != SelectorType.Css)
+                throw new SpiderException("Unsport findy: " + element.Type);
 
-				case SelectorType.XPath:
-					{
-						return webDriver.FindElementByXPath(element.Expression);
-					}
-				case SelectorType.Css:
-					{
-						return webDriver.FindElementByCssSelector(element.Expression);
-					}
-			}
-			throw new SpiderException("Unsport findy: " + element.Type);
-		}
+            if (waitTime > 0)
+            {
+                waitElements(webDriver, element, waitTime);
+            }
+            switch (element.Type)
+            {
 
-		protected RemoteWebDriver GetWebDriver()
-		{
-			ChromeDriverService cds = ChromeDriverService.CreateDefaultService();
-			cds.HideCommandPromptWindow = true;
-			ChromeOptions opt = new ChromeOptions();
-			opt.AddUserProfilePreference("profile", new { default_content_setting_values = new { images = 2 } });
-			RemoteWebDriver webDriver = new ChromeDriver(cds, opt);
+                case SelectorType.XPath:
+                    {
+                        return webDriver.FindElementByXPath(element.Expression);
+                    }
+                case SelectorType.Css:
+                    {
+                        return webDriver.FindElementByCssSelector(element.Expression);
+                    }
+            }
+            return null;
+        }
 
-			webDriver.Manage().Window.Maximize();
-			return webDriver;
-		}
-	}
+        private void waitElements(RemoteWebDriver webDriver, Selector element, int waitTime)
+        {
+            bool canWait = false;
+            canWait = element != null && element.Type == SelectorType.XPath || element.Type == SelectorType.Css;
+            WebDriverWait wait = new WebDriverWait(webDriver, TimeSpan.FromSeconds(10));
+            if (canWait)
+            {
+                if (element.Type == SelectorType.XPath)
+                    wait.Until(ExpectedConditions.ElementExists(By.XPath(element.Expression)));
+                else if (element.Type == SelectorType.Css)
+                    wait.Until(ExpectedConditions.ElementExists(By.CssSelector(element.Expression)));
+            }
+            else
+                Thread.Sleep(waitTime);
+        }
 
-	public class CommonCookieInterceptor : WebDriverCookieInterceptor
-	{
-		public string Url { get; set; }
+        protected RemoteWebDriver GetWebDriver()
+        {
+            ChromeDriverService cds = ChromeDriverService.CreateDefaultService();
+            cds.HideCommandPromptWindow = true;
+            ChromeOptions opt = new ChromeOptions();
+            opt.AddUserProfilePreference("profile", new { default_content_setting_values = new { images = 2 } });
+            RemoteWebDriver webDriver = new ChromeDriver(cds, opt);
 
-		public Selector InputSelector { get; set; }
-
-		public string InputString { get; set; }
-
-		public Selector GotoSelector { get; set; }
-
-		public override Tuple<string, Dictionary<string, string>> GetCookie()
-		{
-			string cookie = string.Empty;
-            var cookies = new Dictionary<string, string>();
-			while (string.IsNullOrEmpty(cookie))
-			{
-				var webDriver = GetWebDriver();
-				try
-				{
-					webDriver.Navigate().GoToUrl(Url);
-					Thread.Sleep(5000);
-
-					if (InputSelector != null)
-					{
-						var input = FindElement(webDriver, InputSelector);
-						if (!string.IsNullOrEmpty(InputString))
-						{
-							input.SendKeys(InputString);
-						}
-					}
-
-					if (GotoSelector != null)
-					{
-						var gotoButton = FindElement(webDriver, GotoSelector);
-						gotoButton.Click();
-						Thread.Sleep(2000);
-					}
-
-					var cookieList = webDriver.Manage().Cookies.AllCookies.ToList();
-
-					if (cookieList.Count > 0)
-					{
-						foreach (var cookieItem in cookieList)
-						{
-							cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
-                            cookies.Add(cookieItem.Name, cookieItem.Value);
-						}
-					}
-
-					webDriver.Dispose();
-				}
-				catch (Exception e)
-				{
-					Logger.Error(e,"Get cookie failed.");
-					webDriver.Dispose();
-					cookie = null;
-				}
-			}
-
-			return new Tuple<string, Dictionary<string, string>>(cookie, cookies);
-		}
-	}
-
-	public class FiddlerCookieInterceptor : CommonCookieInterceptor
-	{
-		public int ProxyPort { get; set; } = 30000;
-		public string Pattern { get; set; }
-
-		public override Tuple<string, Dictionary<string, string>> GetCookie()
-		{
-			if (string.IsNullOrEmpty(Pattern))
-			{
-				throw new Exception("Fiddler CookieTrapper: Pattern cannot be null!");
-			}
-
-			string cookie = string.Empty;
-			using (FiddlerClient fiddlerWrapper = new FiddlerClient(ProxyPort, Pattern))
-			{
-				fiddlerWrapper.StartCapture(true);
-				try
-				{
-					base.GetCookie();
-					var header = fiddlerWrapper.Headers;
-					const string cookiesPattern = @"Cookie: (.*?)\r\n";
-					cookie = Regex.Match(header, cookiesPattern).Groups[1].Value;
-				}
-				catch
-				{
-					// ignored
-				}
-				fiddlerWrapper.StopCapture();
-			}
-            //Item2 not implemented
-            return new Tuple<string, Dictionary<string, string>>(cookie, null);
+            webDriver.Manage().Window.Maximize();
+            return webDriver;
         }
     }
 
-	public class FiddlerLoginCookieInterceptor : LoginCookieInterceptor
-	{
-		public int ProxyPort { get; set; } = 30000;
-		public string Pattern { get; set; }
+    public class CommonCookieInterceptor : WebDriverCookieInterceptor
+    {
+        public string Url { get; set; }
 
-		public override Tuple<string, Dictionary<string, string>> GetCookie()
-		{
-			if (string.IsNullOrEmpty(Pattern))
-			{
-				throw new Exception("Fiddler CookieTrapper: Pattern cannot be null!");
-			}
+        public Selector InputSelector { get; set; }
 
-			string cookie = string.Empty;
-			using (FiddlerClient fiddlerWrapper = new FiddlerClient(ProxyPort, Pattern))
-			{
-				fiddlerWrapper.StartCapture(true);
-				try
-				{
-					base.GetCookie();
-					var header = fiddlerWrapper.Headers;
-					const string cookiesPattern = @"Cookie: (.*?)\r\n";
-					cookie = Regex.Match(header, cookiesPattern).Groups[1].Value;
-				}
-				catch
-				{
-					// ignored
-				}
-				fiddlerWrapper.StopCapture();
-			}
-            //Item2 not implemented
-            return new Tuple<string, Dictionary<string, string>>(cookie, null);
-        }
-    }
+        public string InputString { get; set; }
 
-	public class LoginCookieInterceptor : WebDriverCookieInterceptor
-	{
-		public string Url { get; set; }
+        public Selector GotoSelector { get; set; }
 
-		public string AfterLoginUrl { get; set; }
-
-		public Selector UserSelector { get; set; }
-
-		public string User { get; set; }
-
-		public Selector PassSelector { get; set; }
-
-		public string Pass { get; set; }
-
-		public Selector SubmitSelector { get; set; }
-
-		public Selector LoginAreaSelector { get; set; }
-
-		public override Tuple<string, Dictionary<string, string>> GetCookie()
-		{
-			string cookie = string.Empty;
+        public override Tuple<string, Dictionary<string, string>> GetCookie()
+        {
+            string cookie = string.Empty;
             var cookies = new Dictionary<string, string>();
-			while (string.IsNullOrEmpty(cookie))
-			{
-				var webDriver = GetWebDriver();
-				try
-				{
-					webDriver.Navigate().GoToUrl(Url);
-					Thread.Sleep(10000);
+            while (string.IsNullOrEmpty(cookie))
+            {
+                var webDriver = GetWebDriver();
+                try
+                {
+                    webDriver.Navigate().GoToUrl(Url);
+                    Thread.Sleep(5000);
 
-					if (LoginAreaSelector != null)
-					{
-						var loginArea = FindElement(webDriver, LoginAreaSelector);
-						loginArea.Click();
-						Thread.Sleep(1000);
-					}
+                    if (InputSelector != null)
+                    {
+                        var input = FindElement(webDriver, InputSelector);
+                        if (!string.IsNullOrEmpty(InputString))
+                        {
+                            input.SendKeys(InputString);
+                        }
+                    }
 
-					var user = FindElement(webDriver, UserSelector);
+                    if (GotoSelector != null)
+                    {
+                        var gotoButton = FindElement(webDriver, GotoSelector);
+                        gotoButton.Click();
+                        Thread.Sleep(2000);
+                    }
 
-					user.Clear();
-					user.SendKeys(User);
-					Thread.Sleep(1500);
-					var pass = FindElement(webDriver, PassSelector);
-					pass.SendKeys(Pass);
-					Thread.Sleep(1500);
-					var submit = FindElement(webDriver, SubmitSelector);
-					submit.Click();
-					Thread.Sleep(10000);
+                    var cookieList = webDriver.Manage().Cookies.AllCookies.ToList();
 
-					if (!string.IsNullOrEmpty(AfterLoginUrl))
-					{
-						webDriver.Navigate().GoToUrl(AfterLoginUrl);
-						Thread.Sleep(10000);
-					}
-
-					var cookieList = webDriver.Manage().Cookies.AllCookies.ToList();
-
-					if (cookieList.Count > 0)
-					{
-						foreach (var cookieItem in cookieList)
-						{
-							cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
+                    if (cookieList.Count > 0)
+                    {
+                        foreach (var cookieItem in cookieList)
+                        {
+                            cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
                             cookies.Add(cookieItem.Name, cookieItem.Value);
                         }
                     }
 
-					webDriver.Dispose();
-				}
-				catch (Exception e)
-				{
-					Logger.Error(e, "Get cookie failed.");
-					webDriver.Dispose();
-					cookie = null;
-				}
-			}
+                    webDriver.Dispose();
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Get cookie failed.");
+                    webDriver.Dispose();
+                    cookie = null;
+                }
+            }
+
+            return new Tuple<string, Dictionary<string, string>>(cookie, cookies);
+        }
+    }
+
+    public class FiddlerCookieInterceptor : CommonCookieInterceptor
+    {
+        public int ProxyPort { get; set; } = 30000;
+        public string Pattern { get; set; }
+
+        public override Tuple<string, Dictionary<string, string>> GetCookie()
+        {
+            if (string.IsNullOrEmpty(Pattern))
+            {
+                throw new Exception("Fiddler CookieTrapper: Pattern cannot be null!");
+            }
+
+            string cookie = string.Empty;
+            using (FiddlerClient fiddlerWrapper = new FiddlerClient(ProxyPort, Pattern))
+            {
+                fiddlerWrapper.StartCapture(true);
+                try
+                {
+                    base.GetCookie();
+                    var header = fiddlerWrapper.Headers;
+                    const string cookiesPattern = @"Cookie: (.*?)\r\n";
+                    cookie = Regex.Match(header, cookiesPattern).Groups[1].Value;
+                }
+                catch
+                {
+                    // ignored
+                }
+                fiddlerWrapper.StopCapture();
+            }
+            //Item2 not implemented
+            return new Tuple<string, Dictionary<string, string>>(cookie, null);
+        }
+    }
+
+    public class FiddlerLoginCookieInterceptor : LoginCookieInterceptor
+    {
+        public int ProxyPort { get; set; } = 30000;
+        public string Pattern { get; set; }
+
+        public override Tuple<string, Dictionary<string, string>> GetCookie()
+        {
+            if (string.IsNullOrEmpty(Pattern))
+            {
+                throw new Exception("Fiddler CookieTrapper: Pattern cannot be null!");
+            }
+
+            string cookie = string.Empty;
+            using (FiddlerClient fiddlerWrapper = new FiddlerClient(ProxyPort, Pattern))
+            {
+                fiddlerWrapper.StartCapture(true);
+                try
+                {
+                    base.GetCookie();
+                    var header = fiddlerWrapper.Headers;
+                    const string cookiesPattern = @"Cookie: (.*?)\r\n";
+                    cookie = Regex.Match(header, cookiesPattern).Groups[1].Value;
+                }
+                catch
+                {
+                    // ignored
+                }
+                fiddlerWrapper.StopCapture();
+            }
+            //Item2 not implemented
+            return new Tuple<string, Dictionary<string, string>>(cookie, null);
+        }
+    }
+
+    public class LoginCookieInterceptor : WebDriverCookieInterceptor
+    {
+        public string Url { get; set; }
+
+        public string AfterLoginUrl { get; set; }
+
+        public Selector UserSelector { get; set; }
+
+        public string User { get; set; }
+
+        public Selector PassSelector { get; set; }
+
+        public string Pass { get; set; }
+
+        public Selector SubmitSelector { get; set; }
+
+        public Selector LoginAreaSelector { get; set; }
+
+        public override Tuple<string, Dictionary<string, string>> GetCookie()
+        {
+            string cookie = string.Empty;
+            var cookies = new Dictionary<string, string>();
+            while (string.IsNullOrEmpty(cookie))
+            {
+                var webDriver = GetWebDriver();
+                try
+                {
+                    webDriver.Navigate().GoToUrl(Url);
+
+                    if (LoginAreaSelector != null)
+                    {
+                        IWebElement loginArea = FindElement(webDriver, LoginAreaSelector, 10000);
+                        loginArea.Click();
+                    }
+
+                    var user = FindElement(webDriver, UserSelector, 1000);
+
+                    user.Clear();
+                    user.SendKeys(User);
+                    var pass = FindElement(webDriver, PassSelector,1500);
+                    pass.SendKeys(Pass);
+                    var submit = FindElement(webDriver, SubmitSelector,1500);
+                    
+                    submit.Click();
+
+                    if (!string.IsNullOrEmpty(AfterLoginUrl))
+                    {
+                        webDriver.Navigate().GoToUrl(AfterLoginUrl);
+                        Thread.Sleep(10000);
+                    }
+
+                    var cookieList = webDriver.Manage().Cookies.AllCookies.ToList();
+
+                    if (cookieList.Count > 0)
+                    {
+                        foreach (var cookieItem in cookieList)
+                        {
+                            cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
+                            cookies.Add(cookieItem.Name, cookieItem.Value);
+                        }
+                    }
+
+                    webDriver.Dispose();
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "Get cookie failed.");
+                    webDriver.Dispose();
+                    cookie = null;
+                }
+            }
 
             return new Tuple<string, Dictionary<string, string>>(cookie, cookies);
         }

--- a/src/DotnetSpider.Extension/Downloader/CookieInterceptor.cs
+++ b/src/DotnetSpider.Extension/Downloader/CookieInterceptor.cs
@@ -2,6 +2,7 @@ using System;
 using NLog;
 using DotnetSpider.Core;
 using DotnetSpider.Core.Selector;
+using System.Collections.Generic;
 #if !NET_CORE
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -19,7 +20,7 @@ namespace DotnetSpider.Extension.Downloader
 	{
 		protected readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-		public abstract string GetCookie();
+		public abstract Tuple<string, Dictionary<string, string>> GetCookie();
 	}
 
 #if !NET_CORE
@@ -65,9 +66,10 @@ namespace DotnetSpider.Extension.Downloader
 
 		public Selector GotoSelector { get; set; }
 
-		public override string GetCookie()
+		public override Tuple<string, Dictionary<string, string>> GetCookie()
 		{
 			string cookie = string.Empty;
+            var cookies = new Dictionary<string, string>();
 			while (string.IsNullOrEmpty(cookie))
 			{
 				var webDriver = GetWebDriver();
@@ -99,6 +101,7 @@ namespace DotnetSpider.Extension.Downloader
 						foreach (var cookieItem in cookieList)
 						{
 							cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
+                            cookies.Add(cookieItem.Name, cookieItem.Value);
 						}
 					}
 
@@ -112,7 +115,7 @@ namespace DotnetSpider.Extension.Downloader
 				}
 			}
 
-			return cookie;
+			return new Tuple<string, Dictionary<string, string>>(cookie, cookies);
 		}
 	}
 
@@ -121,7 +124,7 @@ namespace DotnetSpider.Extension.Downloader
 		public int ProxyPort { get; set; } = 30000;
 		public string Pattern { get; set; }
 
-		public override string GetCookie()
+		public override Tuple<string, Dictionary<string, string>> GetCookie()
 		{
 			if (string.IsNullOrEmpty(Pattern))
 			{
@@ -145,16 +148,17 @@ namespace DotnetSpider.Extension.Downloader
 				}
 				fiddlerWrapper.StopCapture();
 			}
-			return cookie;
-		}
-	}
+            //Item2 not implemented
+            return new Tuple<string, Dictionary<string, string>>(cookie, null);
+        }
+    }
 
 	public class FiddlerLoginCookieInterceptor : LoginCookieInterceptor
 	{
 		public int ProxyPort { get; set; } = 30000;
 		public string Pattern { get; set; }
 
-		public override string GetCookie()
+		public override Tuple<string, Dictionary<string, string>> GetCookie()
 		{
 			if (string.IsNullOrEmpty(Pattern))
 			{
@@ -178,9 +182,10 @@ namespace DotnetSpider.Extension.Downloader
 				}
 				fiddlerWrapper.StopCapture();
 			}
-			return cookie;
-		}
-	}
+            //Item2 not implemented
+            return new Tuple<string, Dictionary<string, string>>(cookie, null);
+        }
+    }
 
 	public class LoginCookieInterceptor : WebDriverCookieInterceptor
 	{
@@ -200,9 +205,10 @@ namespace DotnetSpider.Extension.Downloader
 
 		public Selector LoginAreaSelector { get; set; }
 
-		public override string GetCookie()
+		public override Tuple<string, Dictionary<string, string>> GetCookie()
 		{
 			string cookie = string.Empty;
+            var cookies = new Dictionary<string, string>();
 			while (string.IsNullOrEmpty(cookie))
 			{
 				var webDriver = GetWebDriver();
@@ -243,8 +249,9 @@ namespace DotnetSpider.Extension.Downloader
 						foreach (var cookieItem in cookieList)
 						{
 							cookie += cookieItem.Name + "=" + cookieItem.Value + "; ";
-						}
-					}
+                            cookies.Add(cookieItem.Name, cookieItem.Value);
+                        }
+                    }
 
 					webDriver.Dispose();
 				}
@@ -256,8 +263,8 @@ namespace DotnetSpider.Extension.Downloader
 				}
 			}
 
-			return cookie;
-		}
-	}
+            return new Tuple<string, Dictionary<string, string>>(cookie, cookies);
+        }
+    }
 #endif
 }

--- a/src/DotnetSpider.Extension/Downloader/WebDriver/WebDriverDownloader.cs
+++ b/src/DotnetSpider.Extension/Downloader/WebDriver/WebDriverDownloader.cs
@@ -8,6 +8,7 @@ using DotnetSpider.Core.Downloader;
 using DotnetSpider.Core.Common;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
 
 namespace DotnetSpider.Extension.Downloader.WebDriver
 {
@@ -82,11 +83,24 @@ namespace DotnetSpider.Extension.Downloader.WebDriver
 				//中文乱码URL
 				Uri uri = request.Url;
 				string query = uri.Query;
-				string realUrl = uri.Scheme + "://" + uri.DnsSafeHost + (uri.Port == 80 ? "" : (":" + uri.Port)) + uri.AbsolutePath + (string.IsNullOrEmpty(query)
-									? ""
-									: ("?" + HttpUtility.UrlPathEncode(uri.Query.Substring(1, uri.Query.Length - 1))));
+                var domainUrl = string.Format("{0}://{1}{2}", uri.Scheme, uri.DnsSafeHost, uri.Port == 80 ? "" : (":" + uri.Port));
+                //       string realUrl = domainUrl + uri.AbsolutePath + (string.IsNullOrEmpty(query)
+                //? ""
+                //: ("?" + HttpUtility.UrlPathEncode(uri.Query.Substring(1, uri.Query.Length - 1))));
+                string realUrl = HttpUtility.UrlPathEncode(request.Url.AbsoluteUri);
 
-				if (UrlFormat != null)
+                var options = _webDriver.Manage();
+                if (options.Cookies.AllCookies.Count == 0 && spider.Site.Cookies.Count > 0)
+                {
+                    _webDriver.Url = domainUrl;
+                    options.Cookies.DeleteAllCookies();
+                    foreach (var c in spider.Site.Cookies)
+                    {
+                        options.Cookies.AddCookie(new Cookie(c.Key, c.Value));
+                    }
+                }
+
+                if (UrlFormat != null)
 				{
 					realUrl = UrlFormat(realUrl);
 				}
@@ -96,7 +110,20 @@ namespace DotnetSpider.Extension.Downloader.WebDriver
 					_webDriver.Navigate().GoToUrl(realUrl);
 				});
 
-				Thread.Sleep(_webDriverWaitTime);
+                if (Context != null)
+                {
+                    var context = Context as EntitySpider;
+                    var untilMethod = context?.GetConditionMethodByUrl(realUrl);
+                    if (untilMethod != null)
+                    {
+                        dynamic condition;
+                        WebDriverWait wait = new WebDriverWait(_webDriver, TimeSpan.FromSeconds(10));
+                        condition = untilMethod.Invoke(null, null);
+                        wait.Until(condition);
+                    }
+                }
+
+                Thread.Sleep(_webDriverWaitTime);
 
 				AfterNavigate?.Invoke((RemoteWebDriver)_webDriver);
 

--- a/src/DotnetSpider.Extension/EntitySpider.cs
+++ b/src/DotnetSpider.Extension/EntitySpider.cs
@@ -20,620 +20,594 @@ using DotnetSpider.Extension.Processor;
 using DotnetSpider.Extension.Pipeline;
 using DotnetSpider.Core.Pipeline;
 using DotnetSpider.Extension.Downloader;
+using System.Text.RegularExpressions;
 #if NET_CORE
 using System.Runtime.InteropServices;
 #endif
 
 namespace DotnetSpider.Extension
 {
-	public class EntitySpider : Spider
-	{
-		private const string InitStatusSetName = "init-status";
-		private const string ValidateStatusName = "validate-status";
+    public class EntitySpider : Spider
+    {
+        private const string InitStatusSetName = "init-status";
+        private const string ValidateStatusName = "validate-status";
 
-		protected ConnectionMultiplexer Redis;
-		protected IDatabase Db;
+        protected ConnectionMultiplexer Redis;
+        protected IDatabase Db;
 
-		[JsonIgnore]
-		public Action TaskFinished { get; set; } = () => { };
-		[JsonIgnore]
-		public Action VerifyCollectedData { get; set; }
-		public List<EntityMetadata> Entities { get; internal set; } = new List<EntityMetadata>();
-		public RedialExecutor RedialExecutor { get; set; }
-		public List<PrepareStartUrls> PrepareStartUrls { get; set; } = new List<PrepareStartUrls>();
-		public TargetUrlsHandler TargetUrlsHandler { get; set; }
-		public List<TargetUrlExtractor> TargetUrlExtractors { get; set; } = new List<TargetUrlExtractor>();
-		public List<GlobalValueSelector> GlobalValues { get; set; } = new List<GlobalValueSelector>();
-		public CookieInterceptor CookieInterceptor { get; set; }
-		public List<BaseEntityPipeline> EntityPipelines { get; set; } = new List<BaseEntityPipeline>();
-		public int CachedSize { get; set; }
+        [JsonIgnore]
+        public Action TaskFinished { get; set; } = () => { };
+        [JsonIgnore]
+        public Action VerifyCollectedData { get; set; }
+        public List<EntityMetadata> Entities { get; internal set; } = new List<EntityMetadata>();
+        public RedialExecutor RedialExecutor { get; set; }
+        public List<PrepareStartUrls> PrepareStartUrls { get; set; } = new List<PrepareStartUrls>();
+        public TargetUrlsHandler TargetUrlsHandler { get; set; }
+        public List<TargetUrlExtractor> TargetUrlExtractors { get; set; } = new List<TargetUrlExtractor>();
+        public List<GlobalValueSelector> GlobalValues { get; set; } = new List<GlobalValueSelector>();
+        public CookieInterceptor CookieInterceptor { get; set; }
+        public List<BaseEntityPipeline> EntityPipelines { get; set; } = new List<BaseEntityPipeline>();
+        public int CachedSize { get; set; }
+        /// <summary>
+        /// Key: Url patterns. Value: Until condition generators used by webdriverdownloaders.
+        /// </summary>
+        public Dictionary<string, MethodInfo> UntilConditionMethods { get; set; } = new Dictionary<string, MethodInfo>();
 
-		public EntitySpider(Site site)
-		{
-			if (site == null)
-			{
-				throw new SpiderException("Site should not be null.");
-			}
-			Site = site;
-		}
+        public EntitySpider(Site site)
+        {
+            if (site == null)
+            {
+                throw new SpiderException("Site should not be null.");
+            }
+            Site = site;
+        }
 
-		public override void Run(params string[] arguments)
-		{
-			InitEnvoriment();
+        public override void Run(params string[] arguments)
+        {
+            InitEnvoriment();
 
-			try
-			{
+            try
+            {
 #if !NET_CORE
 				if (CookieInterceptor != null)
 				{
 					Logger.Log(LogInfo.Create("尝试获取 Cookie...", Logger.Name, this, LogLevel.Info));
-					string cookie = CookieInterceptor.GetCookie();
-					if (string.IsNullOrEmpty(cookie))
+					var cookie = CookieInterceptor.GetCookie();
+					if (string.IsNullOrEmpty(cookie.Item1))
 					{
 						Logger.Log(LogInfo.Create("获取 Cookie 失败, 爬虫无法继续.", Logger.Name, this, LogLevel.Error));
 						return;
 					}
 					else
 					{
-						Site.Cookie = cookie;
+						Site.Cookie = cookie.Item1;
+                        Site.Cookies = cookie.Item2;
 					}
 				}
 #endif
 
-				Logger.Log(LogInfo.Create("创建爬虫...", Logger.Name, this, LogLevel.Info));
+                Logger.Log(LogInfo.Create("创建爬虫...", Logger.Name, this, LogLevel.Info));
 
-				EntityProcessor processor = new EntityProcessor(this);
-				foreach (var t in TargetUrlExtractors)
-				{
-					processor.AddTargetUrlExtractor(t);
-				}
-				foreach (var entity in Entities)
-				{
-					processor.AddEntity(entity);
-				}
-				if (TargetUrlsHandler != null)
-				{
-					processor.TargetUrlsHandler = TargetUrlsHandler;
-				}
-				PageProcessor = processor;
-				foreach (var entity in Entities)
-				{
-					string entiyName = entity.Entity.Name;
+                EntityProcessor processor = new EntityProcessor(this);
+                foreach (var t in TargetUrlExtractors)
+                {
+                    processor.AddTargetUrlExtractor(t);
+                }
+                foreach (var entity in Entities)
+                {
+                    processor.AddEntity(entity);
+                }
+                if (TargetUrlsHandler != null)
+                {
+                    processor.TargetUrlsHandler = TargetUrlsHandler;
+                }
+                PageProcessor = processor;
+                foreach (var entity in Entities)
+                {
+                    string entiyName = entity.Entity.Name;
 
-					foreach (var pipeline in EntityPipelines)
-					{
-						pipeline.InitiEntity(entity);
-					}
+                    foreach (var pipeline in EntityPipelines)
+                    {
+                        pipeline.InitiEntity(entity);
+                    }
 
-					Pipelines.Add(new EntityPipeline(entiyName, EntityPipelines));
-				}
+                    Pipelines.Add(new EntityPipeline(entiyName, EntityPipelines));
+                }
 
-				CheckIfSettingsCorrect();
+                CheckIfSettingsCorrect();
 
-				bool needInitStartRequest = true;
-				string key = "locker-" + Identity;
-				if (Db != null)
-				{
-					while (!Db.LockTake(key, "0", TimeSpan.FromMinutes(10)))
-					{
-						Thread.Sleep(1000);
-					}
-					var lockerValue = Db.HashGet(InitStatusSetName, Identity);
-					needInitStartRequest = lockerValue != "init finished";
-				}
+                bool needInitStartRequest = true;
+                string key = "locker-" + Identity;
+                if (Db != null)
+                {
+                    while (!Db.LockTake(key, "0", TimeSpan.FromMinutes(10)))
+                    {
+                        Thread.Sleep(1000);
+                    }
+                    var lockerValue = Db.HashGet(InitStatusSetName, Identity);
+                    needInitStartRequest = lockerValue != "init finished";
+                }
 
-				if (arguments.Contains("rerun"))
-				{
-					Scheduler.Clear();
-					needInitStartRequest = true;
-				}
+                if (arguments.Contains("rerun"))
+                {
+                    Scheduler.Clear();
+                    needInitStartRequest = true;
+                }
 
-				Logger.Log(LogInfo.Create("构建内部模块、准备爬虫数据...", Logger.Name, this, LogLevel.Info));
-				if (needInitStartRequest)
-				{
-					if (PrepareStartUrls != null)
-					{
-						foreach (var prepareStartUrl in PrepareStartUrls)
-						{
-							prepareStartUrl.Build(this, null);
-						}
-					}
-				}
-				InitComponent();
-				SpiderMonitor.Default.Register(this);
+                Logger.Log(LogInfo.Create("构建内部模块、准备爬虫数据...", Logger.Name, this, LogLevel.Info));
+                if (needInitStartRequest)
+                {
+                    if (PrepareStartUrls != null)
+                    {
+                        foreach (var prepareStartUrl in PrepareStartUrls)
+                        {
+                            prepareStartUrl.Build(this, null);
+                        }
+                    }
+                }
+                InitComponent();
+                SpiderMonitor.Default.Register(this);
 
-				Db?.LockRelease(key, 0);
+                Db?.LockRelease(key, 0);
 
-				RegisterControl(this);
+                RegisterControl(this);
 
-				base.Run();
+                base.Run();
 
-				TaskFinished();
+                TaskFinished();
 
-				HandleVerifyCollectData();
-			}
-			finally
-			{
-				Dispose();
-				SpiderMonitor.Default.Dispose();
-			}
-		}
+                HandleVerifyCollectData();
+            }
+            finally
+            {
+                Dispose();
+                SpiderMonitor.Default.Dispose();
+            }
+        }
 
-		public EntitySpider AddEntityType(Type type)
-		{
-			CheckIfRunning();
+        public EntitySpider AddEntityType(Type type)
+        {
+            CheckIfRunning();
 
-			if (typeof(ISpiderEntity).IsAssignableFrom(type))
-			{
+            if (typeof(ISpiderEntity).IsAssignableFrom(type))
+            {
+                Entities.Add(ParseMyEntityMetaData(type.GetTypeInfoCrossPlatform()));
+                GlobalValues = type.GetTypeInfo().GetCustomAttributes<GlobalValueSelector>().Select(e => new GlobalValueSelector
+                {
+                    Name = e.Name,
+                    Expression = e.Expression,
+                    Type = e.Type
+                }).ToList();
+            }
+            else
+            {
+                throw new SpiderException($"Type: {type.FullName} is not a ISpiderEntity.");
+            }
+
+            return this;
+        }
+
+        public EntitySpider AddTargetUrlExtractor(TargetUrlExtractor targetUrlExtractor)
+        {
+            CheckIfRunning();
+            TargetUrlExtractors.Add(targetUrlExtractor);
+            return this;
+        }
+
+        public EntitySpider AddEntityPipeline(BaseEntityPipeline pipeline)
+        {
+            CheckIfRunning();
+            EntityPipelines.Add(pipeline);
+            return this;
+        }
+
+        public void SetCachedSize(int count)
+        {
+            CheckIfRunning();
+            foreach (var pipeline in Pipelines)
+            {
+                ((CachedPipeline)pipeline).CachedSize = count;
+            }
+        }
+
+        public override Spider AddPipeline(IPipeline pipeline)
+        {
+            throw new SpiderException("EntitySpider only support AddEntityPipeline.");
+        }
+
+        public override Spider AddPipelines(IList<IPipeline> pipelines)
+        {
+            throw new SpiderException("EntitySpider only support AddEntityPipeline.");
+        }
+
+        public ISpider ToDefaultSpider()
+        {
+            return new DefaultSpider("", new Site());
+        }
+
+        private static string GetEntityName(Type type)
+        {
+            return type.FullName;
+        }
+
+        private void HandleVerifyCollectData()
+        {
+            if (VerifyCollectedData == null)
+            {
+                return;
+            }
+            string key = "locker-validate-" + Identity;
+
+            try
+            {
+                bool needInitStartRequest = true;
+                if (Redis != null)
+                {
+                    while (!Db.LockTake(key, "0", TimeSpan.FromMinutes(10)))
+                    {
+                        Thread.Sleep(1000);
+                    }
+
+                    var lockerValue = Db.HashGet(ValidateStatusName, Identity);
+                    needInitStartRequest = lockerValue != "verify finished";
+                }
+                if (needInitStartRequest)
+                {
+                    Logger.Log(LogInfo.Create("开始执行数据验证...", Logger.Name, this, LogLevel.Info));
+
+                    VerifyCollectedData();
+                }
+
+                Logger.Log(LogInfo.Create("数据验证已完成.", Logger.Name, this, LogLevel.Info));
+
+                if (needInitStartRequest && Redis != null)
+                {
+                    Db.HashSet(ValidateStatusName, Identity, "verify finished");
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, e.Message);
+                throw;
+            }
+            finally
+            {
+                if (Redis != null)
+                {
+                    Db.LockRelease(key, 0);
+                }
+            }
+        }
+
+        private void RegisterControl(Spider spider)
+        {
+            if (Redis != null)
+            {
+                try
+                {
+                    Redis.GetSubscriber().Subscribe($"{spider.Identity}", (c, m) =>
+                    {
+                        switch (m)
+                        {
+                            case "STOP":
+                                {
+                                    spider.Stop();
+                                    break;
+                                }
+                            case "RUNASYNC":
+                                {
+                                    spider.RunAsync();
+                                    break;
+                                }
+                            case "EXIT":
+                                {
+                                    spider.Exit();
+                                    break;
+                                }
+                        }
+                    });
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+        }
+
+        private void InitEnvoriment()
+        {
+            if (RedialExecutor != null)
+            {
+                NetworkCenter.Current.Executor = RedialExecutor;
+            }
+
+            if (!string.IsNullOrEmpty(ConfigurationManager.Get("redisHost")) && string.IsNullOrWhiteSpace(ConfigurationManager.Get("redisHost")))
+            {
+                var host = ConfigurationManager.Get("redisHost");
+
+                var confiruation = new ConfigurationOptions()
+                {
+                    ServiceName = "DotnetSpider",
+                    Password = ConfigurationManager.Get("redisPassword"),
+                    ConnectTimeout = 65530,
+                    KeepAlive = 8,
+                    ConnectRetry = 20,
+                    SyncTimeout = 65530,
+                    ResponseTimeout = 65530
+                };
 #if NET_CORE
-				Entities.Add(PaserEntityMetaData(type.GetTypeInfo()));
-#else
-				Entities.Add(PaserEntityMetaData(type));
-#endif
-				GlobalValues = type.GetTypeInfo().GetCustomAttributes<GlobalValueSelector>().Select(e => new GlobalValueSelector
-				{
-					Name = e.Name,
-					Expression = e.Expression,
-					Type = e.Type
-				}).ToList();
-			}
-			else
-			{
-				throw new SpiderException($"Type: {type.FullName} is not a ISpiderEntity.");
-			}
-
-			return this;
-		}
-
-		public EntitySpider AddTargetUrlExtractor(TargetUrlExtractor targetUrlExtractor)
-		{
-			CheckIfRunning();
-			TargetUrlExtractors.Add(targetUrlExtractor);
-			return this;
-		}
-
-		public EntitySpider AddEntityPipeline(BaseEntityPipeline pipeline)
-		{
-			CheckIfRunning();
-			EntityPipelines.Add(pipeline);
-			return this;
-		}
-
-		public void SetCachedSize(int count)
-		{
-			CheckIfRunning();
-			foreach (var pipeline in Pipelines)
-			{
-				((CachedPipeline)pipeline).CachedSize = count;
-			}
-		}
-
-		public override Spider AddPipeline(IPipeline pipeline)
-		{
-			throw new SpiderException("EntitySpider only support AddEntityPipeline.");
-		}
-
-		public override Spider AddPipelines(IList<IPipeline> pipelines)
-		{
-			throw new SpiderException("EntitySpider only support AddEntityPipeline.");
-		}
-
-		public ISpider ToDefaultSpider()
-		{
-			return new DefaultSpider("", new Site());
-		}
-
-		private static string GetEntityName(Type type)
-		{
-			return type.FullName;
-		}
-
-		private void HandleVerifyCollectData()
-		{
-			if (VerifyCollectedData == null)
-			{
-				return;
-			}
-			string key = "locker-validate-" + Identity;
-
-			try
-			{
-				bool needInitStartRequest = true;
-				if (Redis != null)
-				{
-					while (!Db.LockTake(key, "0", TimeSpan.FromMinutes(10)))
-					{
-						Thread.Sleep(1000);
-					}
-
-					var lockerValue = Db.HashGet(ValidateStatusName, Identity);
-					needInitStartRequest = lockerValue != "verify finished";
-				}
-				if (needInitStartRequest)
-				{
-					Logger.Log(LogInfo.Create("开始执行数据验证...", Logger.Name, this, LogLevel.Info));
-
-					VerifyCollectedData();
-				}
-
-				Logger.Log(LogInfo.Create("数据验证已完成.", Logger.Name, this, LogLevel.Info));
-
-				if (needInitStartRequest && Redis != null)
-				{
-					Db.HashSet(ValidateStatusName, Identity, "verify finished");
-				}
-			}
-			catch (Exception e)
-			{
-				Logger.Error(e, e.Message);
-				throw;
-			}
-			finally
-			{
-				if (Redis != null)
-				{
-					Db.LockRelease(key, 0);
-				}
-			}
-		}
-
-		private void RegisterControl(Spider spider)
-		{
-			if (Redis != null)
-			{
-				try
-				{
-					Redis.GetSubscriber().Subscribe($"{spider.Identity}", (c, m) =>
-					{
-						switch (m)
-						{
-							case "STOP":
-								{
-									spider.Stop();
-									break;
-								}
-							case "RUNASYNC":
-								{
-									spider.RunAsync();
-									break;
-								}
-							case "EXIT":
-								{
-									spider.Exit();
-									break;
-								}
-						}
-					});
-				}
-				catch
-				{
-					// ignored
-				}
-			}
-		}
-
-		private void InitEnvoriment()
-		{
-			if (RedialExecutor != null)
-			{
-				NetworkCenter.Current.Executor = RedialExecutor;
-			}
-
-			if (!string.IsNullOrEmpty(ConfigurationManager.Get("redisHost")) && string.IsNullOrWhiteSpace(ConfigurationManager.Get("redisHost")))
-			{
-				var host = ConfigurationManager.Get("redisHost");
-
-				var confiruation = new ConfigurationOptions()
-				{
-					ServiceName = "DotnetSpider",
-					Password = ConfigurationManager.Get("redisPassword"),
-					ConnectTimeout = 65530,
-					KeepAlive = 8,
-					ConnectRetry = 20,
-					SyncTimeout = 65530,
-					ResponseTimeout = 65530
-				};
-#if NET_CORE
-				if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-				{
-					// Lewis: This is a Workaround for .NET CORE can't use EndPoint to create Socket.
-					var address = Dns.GetHostAddressesAsync(host).Result.FirstOrDefault();
-					if (address == null)
-					{
-						throw new SpiderException("Can't resovle your host: " + host);
-					}
-					confiruation.EndPoints.Add(new IPEndPoint(address, 6379));
-				}
-				else
-				{
-					confiruation.EndPoints.Add(new DnsEndPoint(host, 6379));
-				}
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // Lewis: This is a Workaround for .NET CORE can't use EndPoint to create Socket.
+                    var address = Dns.GetHostAddressesAsync(host).Result.FirstOrDefault();
+                    if (address == null)
+                    {
+                        throw new SpiderException("Can't resovle your host: " + host);
+                    }
+                    confiruation.EndPoints.Add(new IPEndPoint(address, 6379));
+                }
+                else
+                {
+                    confiruation.EndPoints.Add(new DnsEndPoint(host, 6379));
+                }
 #else
 				confiruation.EndPoints.Add(new DnsEndPoint(host, 6379));
 #endif
-				Redis = ConnectionMultiplexer.Connect(confiruation);
-				Db = Redis.GetDatabase(1);
-			}
-		}
+                Redis = ConnectionMultiplexer.Connect(confiruation);
+                Db = Redis.GetDatabase(1);
+            }
+        }
 
+        /// <summary>
+        /// Instance method, use "this" as context.
+        /// </summary>
+        /// <param name="entityType"></param>
+        /// <returns></returns>
+        public EntityMetadata ParseMyEntityMetaData(
 #if !NET_CORE
-		public static EntityMetadata PaserEntityMetaData(Type entityType)
-		{
-			EntityMetadata metadata = new EntityMetadata();
-
-			metadata.Schema = entityType.GetCustomAttribute<Schema>();
-			var indexes = entityType.GetCustomAttribute<Indexes>();
-			if (indexes != null)
-			{
-				metadata.Indexes = indexes.Index?.Select(i => i.Split(',')).ToList();
-				metadata.Uniques = indexes.Unique?.Select(i => i.Split(',')).ToList();
-				metadata.Primary = indexes.Primary?.Split(',');
-				metadata.AutoIncrement = indexes.AutoIncrement;
-			}
-			var updates = entityType.GetCustomAttribute<UpdateColumns>();
-			if (updates != null)
-			{
-				metadata.Updates = updates.Columns;
-			}
-			Entity entity = ParseEntity(entityType);
-			metadata.Entity = entity;
-			EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
-			if (extractByAttribute != null)
-			{
-				metadata.Entity.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
-				metadata.Entity.Multi = true;
-			}
-			else
-			{
-				metadata.Entity.Multi = false;
-			}
-
-			return metadata;
-		}
-
-		private static Entity ParseEntity(Type entityType)
-		{
-			Entity entity = new Entity {Name = GetEntityName(entityType)};
-			var properties = entityType.GetProperties();
-			foreach (var propertyInfo in properties)
-			{
-				var type = propertyInfo.PropertyType;
-
-				if (typeof(ISpiderEntity).IsAssignableFrom(type) || typeof(List<ISpiderEntity>).IsAssignableFrom(type))
-				{
-					Entity token = new Entity();
-					if (typeof(IEnumerable).IsAssignableFrom(type))
-					{
-						token.Multi = true;
-					}
-					else
-					{
-						token.Multi = false;
-					}
-					token.Name = GetEntityName(propertyInfo.PropertyType);
-					EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
-					if (extractByAttribute != null)
-					{
-						token.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
-					}
-					var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
-					if (extractBy != null)
-					{
-						token.Selector = new BaseSelector()
-						{
-							Expression = extractBy.Expression,
-							Type = extractBy.Type,
-							Argument = extractBy.Argument
-						};
-					}
-
-					token.Fields.Add(ParseEntity(propertyInfo.PropertyType));
-				}
-				else
-				{
-					Field token = new Field();
-
-					var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
-					var storeAs = propertyInfo.GetCustomAttribute<StoredAs>();
-
-					if (typeof(IList).IsAssignableFrom(type))
-					{
-						token.Multi = true;
-					}
-					else
-					{
-						token.Multi = false;
-					}
-
-					if (extractBy != null)
-					{
-						token.Option = extractBy.Option;
-						token.Selector = new BaseSelector()
-						{
-							Expression = extractBy.Expression,
-							Type = extractBy.Type,
-							Argument = extractBy.Argument
-						};
-					}
-
-					if (storeAs != null)
-					{
-						token.Name = storeAs.Name;
-						token.DataType = ParseDataType(storeAs);
-					}
-					else
-					{
-						token.Name = propertyInfo.Name;
-					}
-
-					foreach (var formatter in propertyInfo.GetCustomAttributes<Formatter>(true))
-					{
-						token.Formatters.Add(formatter);
-					}
-
-					entity.Fields.Add(token);
-				}
-			}
-			return entity;
-		}
+            Type entityType
 #else
-		public static EntityMetadata PaserEntityMetaData(TypeInfo entityType)
-		{
-			EntityMetadata metadata = new EntityMetadata();
-			metadata.Schema = entityType.GetCustomAttribute<Schema>();
-			var indexes = entityType.GetCustomAttribute<Indexes>();
-			if (indexes != null)
-			{
-				metadata.Indexes = indexes.Index?.Select(i => i.Split(',')).ToList();
-				metadata.Uniques = indexes.Unique?.Select(i => i.Split(',')).ToList();
-				metadata.Primary = indexes.Primary?.Split(',');
-				metadata.AutoIncrement = indexes.AutoIncrement;
-			}
+            TypeInfo entityType
+#endif
+        )
+        {
+            return paserEntityMetaData(entityType, this);
+        }
 
-			var updates = entityType.GetCustomAttribute<UpdateColumns>();
-			if (updates != null)
-			{
-				metadata.Updates = updates.Columns;
-			}
-
-			metadata.Entity = ParseEntity(entityType);
-			EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
-			if (extractByAttribute != null)
-			{
-				metadata.Entity.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
-				metadata.Entity.Multi = true;
-			}
-			else
-			{
-				metadata.Entity.Multi = false;
-			}
-			return metadata;
-		}
-
-		private static Entity ParseEntity(TypeInfo entityType)
-		{
-			Entity entity = new Entity();
-			entity.Name = GetEntityName(entityType.AsType());
-			var properties = entityType.AsType().GetProperties();
-			foreach (var propertyInfo in properties)
-			{
-				var type = propertyInfo.PropertyType;
-
-				if (typeof(ISpiderEntity).IsAssignableFrom(type) || typeof(List<ISpiderEntity>).IsAssignableFrom(type))
-				{
-					Entity token = new Entity();
-					if (typeof(IEnumerable).IsAssignableFrom(type))
-					{
-						token.Multi = true;
-					}
-					else
-					{
-						token.Multi = false;
-					}
-					token.Name = GetEntityName(propertyInfo.PropertyType);
-					EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
-					if (extractByAttribute != null)
-					{
-						token.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
-					}
-					var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
-					if (extractBy != null)
-					{
-						token.Selector = new BaseSelector
-						{
-							Expression = extractBy.Expression,
-							Type = extractBy.Type,
-							Argument = extractBy.Argument
-						};
-					}
-
-					token.Fields.Add(ParseEntity(propertyInfo.PropertyType.GetTypeInfo()));
-				}
-				else
-				{
-					Field token = new Field();
-
-					var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
-					var storeAs = propertyInfo.GetCustomAttribute<StoredAs>();
-
-					if (typeof(IList).IsAssignableFrom(type))
-					{
-						token.Multi = true;
-					}
-					else
-					{
-						token.Multi = false;
-					}
-
-					if (extractBy != null)
-					{
-						token.Option = extractBy.Option;
-						token.Selector = new BaseSelector
-						{
-							Expression = extractBy.Expression,
-							Type = extractBy.Type,
-							Argument = extractBy.Argument
-						};
-					}
-
-					if (storeAs != null)
-					{
-						token.Name = storeAs.Name;
-						token.DataType = ParseDataType(storeAs);
-					}
-					else
-					{
-						token.Name = propertyInfo.Name;
-						token.DataType = "STRING,255";
-					}
-
-					foreach (var formatter in propertyInfo.GetCustomAttributes<Formatter>(true))
-					{
-						token.Formatters.Add(formatter);
-					}
-
-					entity.Fields.Add(token);
-				}
-			}
-			return entity;
-		}
+        public static EntityMetadata PaserEntityMetaData(
+#if !NET_CORE
+            Type entityType
+#else
+            TypeInfo entityType
 #endif
 
-		private static string ParseDataType(StoredAs storedAs)
-		{
-			string reslut = "";
+        )
+        {
+            return paserEntityMetaData(entityType, null);
+        }
 
-			switch (storedAs.Type)
-			{
-				case DataType.Bool:
-					{
-						reslut = "BOOL";
-						break;
-					}
-				case DataType.Date:
-					{
-						reslut = "DATE";
-						break;
-					}
-				case DataType.Time:
-					{
-						reslut = "TIME";
-						break;
-					}
-				case DataType.Text:
-					{
-						reslut = "TEXT";
-						break;
-					}
+        private static EntityMetadata paserEntityMetaData(
+#if !NET_CORE
+            Type entityType, 
+#else
+            TypeInfo entityType,
+#endif
+            EntitySpider es)
+        {
 
-				case DataType.String:
-					{
-						reslut = $"STRING,{storedAs.Lenth}";
-						break;
-					}
-			}
+            EntityMetadata entityMetadata = new EntityMetadata();
 
-			return reslut;
-		}
-	}
+            entityMetadata.Schema = entityType.GetCustomAttribute<Schema>();
+            var indexes = entityType.GetCustomAttribute<Indexes>();
+            if (indexes != null)
+            {
+                entityMetadata.Indexes = indexes.Index?.Select(i => i.Split(',')).ToList();
+                entityMetadata.Uniques = indexes.Unique?.Select(i => i.Split(',')).ToList();
+                entityMetadata.Primary = indexes.Primary?.Split(',');
+                entityMetadata.AutoIncrement = indexes.AutoIncrement;
+            }
+            var updates = entityType.GetCustomAttribute<UpdateColumns>();
+            if (updates != null)
+            {
+                entityMetadata.Updates = updates.Columns;
+            }
+
+            var targetUrls = entityType.GetCustomAttributes<TargetUrl>();
+
+            var conditionFunc = entityType.GetMethod("UntilCondition", BindingFlags.Static | BindingFlags.Public);
+            //If a class definition have TargetUrl and UntilCondition, then add it to es.UntilConditionMethods, TargetUrl as the key.
+            if (targetUrls != null)
+            {
+                entityMetadata.TargetUrls = new string[targetUrls.Count()];
+                int i = 0;
+                foreach (var att in targetUrls)
+                {
+                    var url = att.UrlPattern;
+                    url = att.KeepOrigin ? att.UrlPattern : string.Format("({0})", url.Replace(".", "\\.").Replace("*", "[^\"'#]*"));
+                    entityMetadata.TargetUrls[i] = url;
+                    if (conditionFunc != null && es != null)
+                    {
+                        es.UntilConditionMethods.Add(url, conditionFunc);
+                    }
+                    i++;
+                }
+            }
+            //if a class definition have only UntilCondition, then add it to es.UntilConditionMethods with string.Empty as the key.
+            else if (conditionFunc != null && es != null)
+            {
+                if (!es.UntilConditionMethods.ContainsKey(string.Empty))
+                {
+                    es.UntilConditionMethods.Add(string.Empty, conditionFunc);
+                }
+            }
+
+            Entity entity = ParseEntity(entityType);
+            entityMetadata.Entity = entity;
+            EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
+            if (extractByAttribute != null)
+            {
+                entityMetadata.Entity.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
+            }
+
+            return entityMetadata;
+        }
+
+        private static Entity ParseEntity(
+#if !NET_CORE
+            Type entityType
+#else
+            TypeInfo entityType
+#endif
+        )
+        {
+            Entity entity = new Entity
+            {
+                Name = GetEntityName(entityType.GetTypeCrossPlatform())
+            };
+            var properties = entityType.GetProperties();
+            foreach (var propertyInfo in properties)
+            {
+                var type = propertyInfo.PropertyType;
+
+                if (typeof(ISpiderEntity).IsAssignableFrom(type) || typeof(List<ISpiderEntity>).IsAssignableFrom(type))
+                {
+                    Entity token = new Entity();
+                    if (typeof(IEnumerable).IsAssignableFrom(type))
+                    {
+                        token.Multi = true;
+                    }
+                    else
+                    {
+                        token.Multi = false;
+                    }
+                    token.Name = GetEntityName(propertyInfo.PropertyType);
+                    EntitySelector extractByAttribute = entityType.GetCustomAttribute<EntitySelector>();
+                    if (extractByAttribute != null)
+                    {
+                        token.Selector = new BaseSelector { Expression = extractByAttribute.Expression, Type = extractByAttribute.Type };
+                    }
+                    var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
+                    if (extractBy != null)
+                    {
+                        token.Selector = new BaseSelector()
+                        {
+                            Expression = extractBy.Expression,
+                            Type = extractBy.Type,
+                            Argument = extractBy.Argument
+                        };
+                    }
+
+                    token.Fields.Add(ParseEntity(propertyInfo.PropertyType.GetTypeInfoCrossPlatform()));
+                }
+                else
+                {
+                    Field token = new Field();
+
+                    var extractBy = propertyInfo.GetCustomAttribute<PropertySelector>();
+                    var storeAs = propertyInfo.GetCustomAttribute<StoredAs>();
+
+                    if (typeof(IList).IsAssignableFrom(type))
+                    {
+                        token.Multi = true;
+                    }
+                    else
+                    {
+                        token.Multi = false;
+                    }
+
+                    if (extractBy != null)
+                    {
+                        token.Option = extractBy.Option;
+                        token.Selector = new BaseSelector()
+                        {
+                            Expression = extractBy.Expression,
+                            Type = extractBy.Type,
+                            Argument = extractBy.Argument
+                        };
+                        token.Pattern = extractBy.Pattern;
+                        token.ReplaceString = extractBy.ReplaceString;
+
+                    }
+
+                    if (storeAs != null)
+                    {
+                        token.Name = storeAs.Name;
+                        token.DataType = ParseDataType(storeAs);
+                    }
+                    else
+                    {
+                        token.Name = propertyInfo.Name;
+                    }
+
+                    foreach (var formatter in propertyInfo.GetCustomAttributes<Formatter>(true))
+                    {
+                        token.Formatters.Add(formatter);
+                    }
+
+                    TargetUrl toAddUrl = propertyInfo.GetCustomAttribute<TargetUrl>();
+                    if (toAddUrl != null)
+                    {
+                        var urlExtra = new TargetUrlExtractor();
+                        urlExtra.Region = token.Selector;
+                        if (!string.IsNullOrEmpty(toAddUrl.UrlPattern))
+                        {
+                            urlExtra.Patterns.Add(toAddUrl.UrlPattern);
+                        }
+                        entity.UrlExtras.Add(urlExtra, toAddUrl.OtherPropertiesAsExtras?.ToList());
+                    }
+                    else
+                        entity.Fields.Add(token);
+                }
+            }
+            return entity;
+        }
+
+        public MethodInfo GetConditionMethodByUrl(string url)
+        {
+            foreach (var item in UntilConditionMethods)
+            {
+                if (Regex.IsMatch(url, item.Key))
+                {
+                    return item.Value;
+                }
+            }
+            return null;
+        }
+        private static string ParseDataType(StoredAs storedAs)
+        {
+            string reslut = "";
+
+            switch (storedAs.Type)
+            {
+                case DataType.Bool:
+                    {
+                        reslut = "BOOL";
+                        break;
+                    }
+                case DataType.Date:
+                    {
+                        reslut = "DATE";
+                        break;
+                    }
+                case DataType.Time:
+                    {
+                        reslut = "TIME";
+                        break;
+                    }
+                case DataType.Text:
+                    {
+                        reslut = "TEXT";
+                        break;
+                    }
+
+                case DataType.String:
+                    {
+                        reslut = $"STRING,{storedAs.Lenth}";
+                        break;
+                    }
+            }
+
+            return reslut;
+        }
+    }
 }

--- a/src/DotnetSpider.Extension/EntitySpider.cs
+++ b/src/DotnetSpider.Extension/EntitySpider.cs
@@ -524,9 +524,6 @@ namespace DotnetSpider.Extension
                             Type = extractBy.Type,
                             Argument = extractBy.Argument
                         };
-                        token.Pattern = extractBy.Pattern;
-                        token.ReplaceString = extractBy.ReplaceString;
-
                     }
 
                     if (storeAs != null)

--- a/src/DotnetSpider.Extension/EntitySpider.cs
+++ b/src/DotnetSpider.Extension/EntitySpider.cs
@@ -105,13 +105,15 @@ namespace DotnetSpider.Extension
                 foreach (var entity in Entities)
                 {
                     string entiyName = entity.Entity.Name;
+                    List<BaseEntityPipeline> pls = new List<BaseEntityPipeline>();
 
                     foreach (var pipeline in EntityPipelines)
                     {
-                        pipeline.InitiEntity(entity);
+                        var newP = pipeline.CreateNewByInitEntity(entity);
+                        pls.Add(newP);
                     }
 
-                    Pipelines.Add(new EntityPipeline(entiyName, EntityPipelines));
+                    Pipelines.Add(new EntityPipeline(entiyName, pls));
                 }
 
                 CheckIfSettingsCorrect();

--- a/src/DotnetSpider.Extension/Model/Attribute/PropertySelector.cs
+++ b/src/DotnetSpider.Extension/Model/Attribute/PropertySelector.cs
@@ -18,13 +18,5 @@ namespace DotnetSpider.Extension.Model.Attribute
 		public bool NotNull { get; set; }
 
 		public ValueOption Option { get; set; } = ValueOption.None;
-        /// <summary>
-        /// Get the part matching the pattern from the value extracted.
-        /// </summary>
-        public string Pattern { get; set; }
-        /// <summary>
-        /// Work together with "Pattern", generate a new result string by a regex replacing.
-        /// </summary>
-        public string ReplaceString { get; set; }
 	}
 }

--- a/src/DotnetSpider.Extension/Model/Attribute/PropertySelector.cs
+++ b/src/DotnetSpider.Extension/Model/Attribute/PropertySelector.cs
@@ -18,5 +18,13 @@ namespace DotnetSpider.Extension.Model.Attribute
 		public bool NotNull { get; set; }
 
 		public ValueOption Option { get; set; } = ValueOption.None;
+        /// <summary>
+        /// Get the part matching the pattern from the value extracted.
+        /// </summary>
+        public string Pattern { get; set; }
+        /// <summary>
+        /// Work together with "Pattern", generate a new result string by a regex replacing.
+        /// </summary>
+        public string ReplaceString { get; set; }
 	}
 }

--- a/src/DotnetSpider.Extension/Model/Attribute/TargetUrl.cs
+++ b/src/DotnetSpider.Extension/Model/Attribute/TargetUrl.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotnetSpider.Extension.Model.Attribute
+{
+    /// <summary>
+    /// Define the url patterns for class.
+    /// All urls matching the pattern will be crawled and extracted for new objects.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, AllowMultiple = true)]
+    public class TargetUrl : System.Attribute
+    {
+        /// <summary>
+        /// The url patterns for class.
+        /// Use regex expression with some changes:
+        ///      "." stand for literal character "." instead of "any character".
+        ///      "*" stand for any legal character for url in 0-n length ([^"'#]*) instead of "any length".
+        /// </summary>
+        public string UrlPattern { get; set; }
+        /// <summary>
+        /// The properties' name from which the extras of the new reuqest with get from.
+        /// </summary>
+        public string[] OtherPropertiesAsExtras { get; set; }
+        /// <summary>
+        /// Use the UrlPattern as pure regex without any changes(no "." and "*" transformation).
+        /// </summary>
+        public bool KeepOrigin { get; set; }
+    }
+}

--- a/src/DotnetSpider.Extension/Model/EntityExtractor.cs
+++ b/src/DotnetSpider.Extension/Model/EntityExtractor.cs
@@ -141,17 +141,6 @@ namespace DotnetSpider.Extension.Model
                 var fieldValue = ExtractField(item, page, field, index);
                 if (fieldValue != null)
                 {
-                    if (!string.IsNullOrEmpty(field.Pattern))
-                    {
-                        if (string.IsNullOrEmpty(field.ReplaceString))
-                        {
-                            fieldValue = Regex.Match(fieldValue, field.Pattern).ToString();
-                        }
-                        else
-                        {
-                            fieldValue = Regex.Replace(fieldValue, field.Pattern, field.ReplaceString);
-                        }
-                    }
                     dataObject.Add(field.Name, fieldValue);
                 }
             }

--- a/src/DotnetSpider.Extension/Model/EntityExtractor.cs
+++ b/src/DotnetSpider.Extension/Model/EntityExtractor.cs
@@ -7,261 +7,304 @@ using DotnetSpider.Extension.Model.Attribute;
 using DotnetSpider.Core.Common;
 using DotnetSpider.Extension.Common;
 using Newtonsoft.Json.Linq;
+using System.Text.RegularExpressions;
 
 namespace DotnetSpider.Extension.Model
 {
-	public class EntityExtractor : IEntityExtractor
-	{
-		private readonly EntityMetadata _entityDefine;
-		private readonly List<GlobalValueSelector> _globalValues;
+    public class EntityExtractor : IEntityExtractor
+    {
+        private readonly EntityMetadata _entityDefine;
+        private readonly List<GlobalValueSelector> _globalValues;
 
-		public EntityExtractor(string entityName, List<GlobalValueSelector> globalValues, EntityMetadata entityDefine)
-		{
-			_entityDefine = entityDefine;
+        public EntityExtractor(string entityName, List<GlobalValueSelector> globalValues, EntityMetadata entityDefine)
+        {
+            _entityDefine = entityDefine;
 
-			EntityName = entityName;
-			_globalValues = globalValues;
-		}
+            EntityName = entityName;
+            _globalValues = globalValues;
+        }
 
-		public List<JObject> Process(Page page)
-		{
-			if (_globalValues != null && _globalValues.Count > 0)
-			{
-				foreach (var enviromentValue in _globalValues)
-				{
-					string name = enviromentValue.Name;
-					var value = page.Selectable.Select(SelectorUtil.Parse(enviromentValue)).GetValue();
-					page.Request.PutExtra(name, value);
-				}
-			}
-			ISelector selector = SelectorUtil.Parse(_entityDefine.Entity.Selector);
-			if (selector != null && _entityDefine.Entity.Multi)
-			{
-				var list = page.Selectable.SelectList(selector).Nodes();
-				if (list == null || list.Count == 0)
-				{
-					return null;
-				}
-				var countToken = _entityDefine.Limit;
-				if (countToken != null)
-				{
-					list = list.Take(countToken.Value).ToList();
-				}
+        public List<JObject> Process(Page page)
+        {
+            bool isTarget = true;
+            foreach (var url in _entityDefine.TargetUrls)
+            {
+                isTarget = Regex.IsMatch(page.Url, url, RegexOptions.IgnoreCase);
+                if (isTarget) break;
+            }
+            if (!isTarget) return null;
+            if (_globalValues != null && _globalValues.Count > 0)
+            {
+                foreach (var enviromentValue in _globalValues)
+                {
+                    string name = enviromentValue.Name;
+                    var value = page.Selectable.Select(SelectorUtil.Parse(enviromentValue)).GetValue();
+                    page.Request.PutExtra(name, value);
+                }
+            }
+            ISelector selector = SelectorUtil.Parse(_entityDefine.Entity.Selector);
+            if (selector != null)
+            {
+                var list = page.Selectable.SelectList(selector).Nodes();
+                if (list == null || list.Count == 0)
+                {
+                    return null;
+                }
+                var countToken = _entityDefine.Limit;
+                if (countToken != null)
+                {
+                    list = list.Take(countToken.Value).ToList();
+                }
 
-				List<JObject> result = new List<JObject>();
-				int index = 0;
-				foreach (var item in list)
-				{
-					JObject obj = ProcessSingle(page, item, _entityDefine, index);
-					if (obj != null)
-					{
-						result.Add(obj);
-					}
-					index++;
-				}
-				return result;
-			}
-			else
-			{
-				ISelectable select;
-				if (selector == null)
-				{
-					select = page.Selectable;
-				}
-				else
-				{
-					select = page.Selectable.Select(selector);
-					if (select == null)
-					{
-						return null;
-					}
-				}
+                List<JObject> result = new List<JObject>();
+                int index = 0;
+                foreach (var item in list)
+                {
+                    JObject obj = ProcessSingle(page, item, _entityDefine, index);
+                    if (obj != null)
+                    {
+                        result.Add(obj);
+                    }
+                    index++;
+                }
+                return result;
+            }
+            else
+            {
+                ISelectable select;
+                if (selector == null)
+                {
+                    select = page.Selectable;
+                }
+                else
+                {
+                    select = page.Selectable.Select(selector);
+                    if (select == null)
+                    {
+                        return null;
+                    }
+                }
 
-				var result = ProcessSingle(page, select, _entityDefine, 0);
-				return result == null ? null : new List<JObject> { result };
-			}
-		}
+                var result = ProcessSingle(page, select, _entityDefine, 0);
+                return result == null ? null : new List<JObject> { result };
+            }
+        }
 
-		private string GetEnviromentValue(string field, Page page, int index)
-		{
-			if (field.ToLower() == "url")
-			{
-				return page.Url;
-			}
+        private string GetEnviromentValue(string field, Page page, int index)
+        {
+            if (field.ToLower() == "url")
+            {
+                return page.Url;
+            }
 
-			if (field.ToLower() == "targeturl")
-			{
-				return page.TargetUrl;
-			}
+            if (field.ToLower() == "targeturl")
+            {
+                return page.TargetUrl;
+            }
 
-			if (field.ToLower() == "now")
-			{
-				return DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
-			}
+            if (field.ToLower() == "now")
+            {
+                return DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+            }
 
-			if (field.ToLower() == "monday")
-			{
-				return DateTimeUtils.MondayRunId;
-			}
+            if (field.ToLower() == "monday")
+            {
+                return DateTimeUtils.MondayRunId;
+            }
 
-			if (field.ToLower() == "today")
-			{
-				return DateTimeUtils.TodayRunId;
-			}
+            if (field.ToLower() == "today")
+            {
+                return DateTimeUtils.TodayRunId;
+            }
 
-			if (field.ToLower() == "index")
-			{
-				return index.ToString();
-			}
+            if (field.ToLower() == "index")
+            {
+                return index.ToString();
+            }
 
-			if (!page.Request.ExistExtra(field))
-			{
-				return field;
-			}
-			else
-			{
-				return page.Request.GetExtra(field)?.ToString();
-			}
-		}
+            if (!page.Request.ExistExtra(field))
+            {
+                return field;
+            }
+            else
+            {
+                return page.Request.GetExtra(field)?.ToString();
+            }
+        }
 
-		private JObject ProcessSingle(Page page, ISelectable item, EntityMetadata entityDefine, int index)
-		{
-			JObject dataObject = new JObject();
+        private JObject ProcessSingle(Page page, ISelectable item, EntityMetadata entityDefine, int index)
+        {
+            JObject dataObject = new JObject();
 
-			foreach (var field in entityDefine.Entity.Fields)
-			{
-				var fieldValue = ExtractField(item, page, field, index);
-				if (fieldValue != null)
-				{
-					dataObject.Add(field.Name, fieldValue);
-				}
-			}
+            foreach (var field in entityDefine.Entity.Fields)
+            {
+                var fieldValue = ExtractField(item, page, field, index);
+                if (fieldValue != null)
+                {
+                    if (!string.IsNullOrEmpty(field.Pattern))
+                    {
+                        if (string.IsNullOrEmpty(field.ReplaceString))
+                        {
+                            fieldValue = Regex.Match(fieldValue, field.Pattern).ToString();
+                        }
+                        else
+                        {
+                            fieldValue = Regex.Replace(fieldValue, field.Pattern, field.ReplaceString);
+                        }
+                    }
+                    dataObject.Add(field.Name, fieldValue);
+                }
+            }
+            List<TargetUrlExtractor> extractors = new List<TargetUrlExtractor>();
+            foreach (var field in entityDefine.Entity.UrlExtras)
+            {
+                TargetUrlExtractor newExt = field.Key.Clone();
+                if (field.Value != null)
+                {
+                    foreach (var p in field.Value)
+                    {
+                        JToken v;
+                        dataObject.TryGetValue(p,
+#if !NET_CORE
+                            StringComparison.InvariantCultureIgnoreCase, out v);
+#else
+                            StringComparison.OrdinalIgnoreCase, out v);
+#endif
+                        if (v != null)
+                        {
+                            newExt.Extras.Add(p, v);
+                        }
+                    }
+                }
+                extractors.Add(newExt);
+            }
+            SelectorUtil.ExtractLinks(item, page, extractors);
 
-			return dataObject.Children().Any() ? dataObject : null;
-		}
+            return dataObject.Children().Any() ? dataObject : null;
+        }
 
-		private dynamic ExtractField(ISelectable item, Page page, DataToken field, int index)
-		{
-			ISelector selector = SelectorUtil.Parse(field.Selector);
-			if (selector == null)
-			{
-				return null;
-			}
+        private dynamic ExtractField(ISelectable item, Page page, DataToken field, int index)
+        {
+            ISelector selector = SelectorUtil.Parse(field.Selector);
+            if (selector == null)
+            {
+                return null;
+            }
 
-			var f = field as Field;
+            var f = field as Field;
 
-			bool isEntity = field is Entity;
+            bool isEntity = field is Entity;
 
-			if (!isEntity)
-			{
-				string tmpValue;
-				if (selector is EnviromentSelector)
-				{
-					var enviromentSelector = selector as EnviromentSelector;
-					tmpValue = GetEnviromentValue(enviromentSelector.Field, page, index);
-					if (f != null)
-					{
-						foreach (var formatter in f.Formatters)
-						{
-							tmpValue = formatter.Formate(tmpValue);
-						}
-					}
-					return tmpValue;
-				}
-				else
-				{
-					bool needPlainText = ((Field)field).Option == PropertySelector.ValueOption.PlainText;
-					if (field.Multi)
-					{
-						var propertyValues = item.SelectList(selector).Nodes();
+            if (!isEntity)
+            {
+                string tmpValue;
+                if (selector is EnviromentSelector)
+                {
+                    var enviromentSelector = selector as EnviromentSelector;
+                    tmpValue = GetEnviromentValue(enviromentSelector.Field, page, index);
+                    if (f != null)
+                    {
+                        foreach (var formatter in f.Formatters)
+                        {
+                            tmpValue = formatter.Formate(tmpValue);
+                        }
+                    }
+                    return tmpValue;
+                }
+                else
+                {
+                    bool needPlainText = ((Field)field).Option == PropertySelector.ValueOption.PlainText;
+                    if (field.Multi)
+                    {
+                        var propertyValues = item.SelectList(selector).Nodes();
 
-						List<string> results = new List<string>();
-						foreach (var propertyValue in propertyValues)
-						{
-							string tmp = propertyValue.GetValue(needPlainText);
-							if (f != null)
-							{
-								foreach (var formatter in f.Formatters)
-								{
-									tmp = formatter.Formate(tmp);
-								}
-							}
-							results.Add(tmp);
-						}
-						return new JArray(results);
-					}
-					else
-					{
-						bool needCount = (((Field)field).Option == PropertySelector.ValueOption.Count);
-						if (needCount)
-						{
-							var propertyValues = item.SelectList(selector).Nodes();
-							return propertyValues?.Count.ToString() ?? "-1";
-						}
-						else
-						{
-							tmpValue = item.Select(selector)?.GetValue(needPlainText);
-							if (f != null)
-							{
-								foreach (var formatter in f.Formatters)
-								{
-									tmpValue = formatter.Formate(tmpValue);
-								}
-							}
-							return tmpValue;
-						}
-					}
-				}
-			}
-			else
-			{
-				if (field.Multi)
-				{
-					JArray objs = new JArray();
-					var selectables = item.SelectList(selector).Nodes();
-					foreach (var selectable in selectables)
-					{
-						JObject obj = new JObject();
+                        List<string> results = new List<string>();
+                        foreach (var propertyValue in propertyValues)
+                        {
+                            string tmp = propertyValue.GetValue(needPlainText);
+                            if (f != null)
+                            {
+                                foreach (var formatter in f.Formatters)
+                                {
+                                    tmp = formatter.Formate(tmp);
+                                }
+                            }
+                            results.Add(tmp);
+                        }
+                        return new JArray(results);
+                    }
+                    else
+                    {
+                        bool needCount = (((Field)field).Option == PropertySelector.ValueOption.Count);
+                        if (needCount)
+                        {
+                            var propertyValues = item.SelectList(selector).Nodes();
+                            return propertyValues?.Count.ToString() ?? "-1";
+                        }
+                        else
+                        {
+                            tmpValue = item.Select(selector)?.GetValue(needPlainText);
+                            if (f != null)
+                            {
+                                foreach (var formatter in f.Formatters)
+                                {
+                                    tmpValue = formatter.Formate(tmpValue);
+                                }
+                            }
+                            return tmpValue;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (field.Multi)
+                {
+                    JArray objs = new JArray();
+                    var selectables = item.SelectList(selector).Nodes();
+                    foreach (var selectable in selectables)
+                    {
+                        JObject obj = new JObject();
 
-						foreach (var child in ((Entity)field).Fields)
-						{
-							obj.Add(child.Name, ExtractField(selectable, page, child, 0));
-						}
-						objs.Add(obj);
-					}
-					return objs;
-				}
-				else
-				{
-					JObject obj = new JObject();
-					var selectable = item.Select(selector);
-					foreach (var child in ((Entity)field).Fields)
-					{
-						obj.Add(child.Name, ExtractField(selectable, page, field, 0));
-					}
-					return obj;
-				}
-			}
-		}
+                        foreach (var child in ((Entity)field).Fields)
+                        {
+                            obj.Add(child.Name, ExtractField(selectable, page, child, 0));
+                        }
+                        objs.Add(obj);
+                    }
+                    return objs;
+                }
+                else
+                {
+                    JObject obj = new JObject();
+                    var selectable = item.Select(selector);
+                    foreach (var child in ((Entity)field).Fields)
+                    {
+                        obj.Add(child.Name, ExtractField(selectable, page, field, 0));
+                    }
+                    return obj;
+                }
+            }
+        }
 
-		//public static List<Formatter.Formatter> GenerateFormatter(IEnumerable<JToken> selectTokens)
-		//{
-		//	if (selectTokens == null)
-		//	{
-		//		return new List<Formatter.Formatter>();
-		//	}
-		//	var results = new List<Formatter.Formatter>();
-		//	foreach (var selectToken in selectTokens)
-		//	{
-		//		Type type = FormatterFactory.GetFormatterType(selectToken.SelectToken("$.Name")?.ToString());
-		//		if (type != null)
-		//		{
-		//			results.Add(selectToken.ToObject(type) as Formatter.Formatter);
-		//		}
-		//	}
-		//	return results;
-		//}
+        //public static List<Formatter.Formatter> GenerateFormatter(IEnumerable<JToken> selectTokens)
+        //{
+        //	if (selectTokens == null)
+        //	{
+        //		return new List<Formatter.Formatter>();
+        //	}
+        //	var results = new List<Formatter.Formatter>();
+        //	foreach (var selectToken in selectTokens)
+        //	{
+        //		Type type = FormatterFactory.GetFormatterType(selectToken.SelectToken("$.Name")?.ToString());
+        //		if (type != null)
+        //		{
+        //			results.Add(selectToken.ToObject(type) as Formatter.Formatter);
+        //		}
+        //	}
+        //	return results;
+        //}
 
-		public string EntityName { get; }
-	}
+        public string EntityName { get; }
+    }
 }

--- a/src/DotnetSpider.Extension/Model/EntityMetadata.cs
+++ b/src/DotnetSpider.Extension/Model/EntityMetadata.cs
@@ -42,7 +42,5 @@ namespace DotnetSpider.Extension.Model
 		public BaseSelector Selector { get; set; }
 		public bool Multi { get; set; }
 		public string Name { get; set; }
-        public string Pattern { get; set; }
-        public string ReplaceString { get; set; }
 	}
 }

--- a/src/DotnetSpider.Extension/Model/EntityMetadata.cs
+++ b/src/DotnetSpider.Extension/Model/EntityMetadata.cs
@@ -14,11 +14,20 @@ namespace DotnetSpider.Extension.Model
 		public Entity Entity { get; set; } = new Entity();
 		public string[] Updates { get; internal set; }
 		public int? Limit { get; set; }
+        /// <summary>
+        /// The corresponding url pattern(s).
+        /// </summary>
+        public string[] TargetUrls { get; set; }
 	}
 
 	public class Entity : DataToken
 	{
 		public List<DataToken> Fields { get; set; } = new List<DataToken>();
+        /// <summary>
+        /// Key: The Url extractors generated from the entity definition. Value: the properties' name from which the extras of the new reuqest with get from.
+        /// </summary>
+        public Dictionary<TargetUrlExtractor, List<string>> UrlExtras { get; set; }
+            = new Dictionary<TargetUrlExtractor, List<string>>();
 	}
 
 	public class Field : DataToken
@@ -33,5 +42,7 @@ namespace DotnetSpider.Extension.Model
 		public BaseSelector Selector { get; set; }
 		public bool Multi { get; set; }
 		public string Name { get; set; }
+        public string Pattern { get; set; }
+        public string ReplaceString { get; set; }
 	}
 }

--- a/src/DotnetSpider.Extension/Model/TargetUrlExtractor.cs
+++ b/src/DotnetSpider.Extension/Model/TargetUrlExtractor.cs
@@ -7,5 +7,29 @@ namespace DotnetSpider.Extension.Model
 		public List<string> Patterns { get; set; } = new List<string>();
 		public List<Formatter.Formatter> Formatters { get; set; }
 		public Selector Region { get; set; }
-	}
+        public Dictionary<string, dynamic> Extras { get; set; } = new Dictionary<string, dynamic>();
+
+        public TargetUrlExtractor Clone()
+        {
+            var result = new TargetUrlExtractor();
+            foreach (var item in Patterns)
+            {
+                result.Patterns.Add(item);
+            }
+            if (Formatters != null)
+            {
+                result.Formatters = new List<Formatter.Formatter>();
+                foreach (var item in Formatters)
+                {
+                    result.Formatters.Add(item);
+                }
+            }
+            result.Region = Region;
+            foreach (var item in Extras)
+            {
+                result.Extras.Add(item.Key, item.Value);
+            }
+            return result;
+        }
+    }
 }

--- a/src/DotnetSpider.Extension/Pipeline/BaseEntityDbPipeline.cs
+++ b/src/DotnetSpider.Extension/Pipeline/BaseEntityDbPipeline.cs
@@ -120,8 +120,8 @@ namespace DotnetSpider.Extension.Pipeline
                 }
                 else
                 {
-                    newObject.UpdateColumns = Columns;
-                    newObject.UpdateColumns.RemoveAll(c => Primary.Contains(c));
+                    newObject.UpdateColumns = newObject.Columns;
+                    newObject.UpdateColumns.RemoveAll(c => newObject.Primary.Contains(c));
 
                     if (newObject.UpdateColumns.Count == 0)
                     {

--- a/src/DotnetSpider.Extension/Pipeline/BaseEntityPipeline.cs
+++ b/src/DotnetSpider.Extension/Pipeline/BaseEntityPipeline.cs
@@ -20,7 +20,7 @@ namespace DotnetSpider.Extension.Pipeline
         /// When there are multiple entities, every original pipeline instance is somehow sort of a "template", for there should be 
         /// every single pipelines created for every single entity definition. That's why we have this method.
         /// Please reference to the Run method of EntitySpider class where this method is called. theoretically all the sub class of this class should override
-        /// this method.
+        /// this method to support multi-entity scenario.
         /// </summary>
         /// <param name="metadata"></param>
         /// <returns>the new created instance.</returns>

--- a/src/DotnetSpider.Extension/Pipeline/BaseEntityPipeline.cs
+++ b/src/DotnetSpider.Extension/Pipeline/BaseEntityPipeline.cs
@@ -15,6 +15,21 @@ namespace DotnetSpider.Extension.Pipeline
 
 		public abstract void InitiEntity(EntityMetadata metadata);
 
+        /// <summary>
+        /// Create new instance, copy property values and initialize it by entity metadata. the default implementation is simply calling InitEntity method.
+        /// When there are multiple entities, every original pipeline instance is somehow sort of a "template", for there should be 
+        /// every single pipelines created for every single entity definition. That's why we have this method.
+        /// Please reference to the Run method of EntitySpider class where this method is called. theoretically all the sub class of this class should override
+        /// this method.
+        /// </summary>
+        /// <param name="metadata"></param>
+        /// <returns>the new created instance.</returns>
+        public virtual BaseEntityPipeline CreateNewByInitEntity(EntityMetadata metadata)
+        {
+            InitiEntity(metadata);
+            return this;
+        }
+
 		public virtual void InitPipeline(ISpider spider)
 		{
 			Spider = spider;

--- a/src/DotnetSpider.Extension/Pipeline/MSSqlEntityPipeline.cs
+++ b/src/DotnetSpider.Extension/Pipeline/MSSqlEntityPipeline.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Data.SqlClient;
+
+namespace DotnetSpider.Extension.Pipeline
+{
+    using Core;
+    using Core.Common;
+    using SQL = DotnetSpider.Extension.SQL.MSSql.SQL;
+    public class MSSqlEntityPipeline : BaseEntityDbPipeline
+    {
+        public MSSqlEntityPipeline()
+        { }
+
+        public MSSqlEntityPipeline(string connectString, PipelineMode mode = PipelineMode.Insert) : base(connectString, mode)
+		{
+        }
+
+        protected override string ConvertToDbType(string dataType)
+        {
+            var match = RegexUtil.NumRegex.Match(dataType);
+            var length = match.Length == 0 ? 0 : int.Parse(match.Value);
+
+            if (dataType.StartsWith("STRING,"))
+            {
+                return length == 0 ? "NVARCHAR(100)" : $"NVARCHAR({length})";
+            }
+
+            if ("DATE" == dataType)
+            {
+                return "datetime ";
+            }
+
+            if ("BOOL" == dataType)
+            {
+                return "bit ";
+            }
+
+            if ("TIME" == dataType)
+            {
+                return "datetime ";
+            }
+
+            if ("TEXT" == dataType)
+            {
+                return "nvarchar(max)";
+            }
+
+            throw new SpiderException("UNSPORT datatype: " + dataType);
+        }
+
+        protected override DbConnection CreateConnection()
+        {
+            return new SqlConnection(ConnectString);
+        }
+
+        protected override DbParameter CreateDbParameter()
+        {
+            return new SqlParameter();
+        }
+
+        protected override string GetCreateSchemaSql()
+        {
+            return string.Empty;
+        }
+
+        protected override string GetCreateTableSql()
+        {
+            var table = SQL.CreateTable(Schema.TableName, true);
+            foreach (var col in Columns)
+            {
+                table.AddColumn(col.Name, ConvertToDbType(col.DataType));
+            }
+            if (Primary == null || Primary.Count == 0)
+            {
+                table.AddColumn("__id", "int", "IDENTITY(1,1)", "", false);
+            }
+            return table.toCommand().getStatement();
+        }
+
+        protected override string GetInsertSql()
+        {
+            var table = SQL.INSERT(Schema.TableName);
+            foreach (var col in Columns)
+            {
+                table.Values(col.Name, $"@{col.Name}");
+            }
+            return table.toCommand().getStatement();
+        }
+
+        protected override string GetUpdateSql()
+        {
+            var table = SQL.UPDATE(Schema.TableName);
+            foreach (var col in UpdateColumns)
+            {
+                table.Set(col.Name, $"@{col.Name}");
+            }
+            foreach (var col in Primary)
+            {
+                table.Where(col.Name, $"@{col.Name}");
+            }
+            return table.toCommand().getStatement();
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/Processor/EntityProcessor.cs
+++ b/src/DotnetSpider.Extension/Processor/EntityProcessor.cs
@@ -10,21 +10,17 @@ using DotnetSpider.Extension.Model.Formatter;
 using DotnetSpider.Core.Selector;
 using DotnetSpider.Extension.Common;
 using Newtonsoft.Json.Linq;
-#if !NET_CORE
-using System.Web;
-#else
-using System.Net;
-#endif
 
 namespace DotnetSpider.Extension.Processor
 {
 	public class EntityProcessor : IPageProcessor
 	{
-		private class TargetUrlExtractorInfo
+		internal class TargetUrlExtractorInfo
 		{
 			public List<Regex> Patterns { get; set; } = new List<Regex>();
 			public List<Formatter> Formatters { get; set; }
 			public ISelector Region { get; set; }
+            public Dictionary<string, dynamic> Extras { get; set; } = new Dictionary<string, dynamic>();
 		}
 
 		protected readonly IList<IEntityExtractor> EntityExtractorList = new List<IEntityExtractor>();
@@ -96,7 +92,7 @@ namespace DotnetSpider.Extension.Processor
 			{
 				if (TargetUrlsHandler == null)
 				{
-					ExtractLinks(page, TargetUrlExtractors);
+					SelectorUtil.ExtractLinks(null, page, TargetUrlExtractors);
 				}
 				else
 				{
@@ -107,76 +103,6 @@ namespace DotnetSpider.Extension.Processor
 			if (page.ResultItems.Results.Count == 0)
 			{
 				page.ResultItems.IsSkip = true;
-			}
-		}
-
-		/// <summary>
-		/// 如果找不到则不返回URL, 不然返回的URL太多
-		/// </summary>
-		/// <param name="page"></param>
-		/// <param name="targetUrlExtractInfos"></param>
-		private void ExtractLinks(Page page, List<TargetUrlExtractorInfo> targetUrlExtractInfos)
-		{
-			if (targetUrlExtractInfos == null)
-			{
-				return;
-			}
-
-			foreach (var targetUrlExtractInfo in targetUrlExtractInfos)
-			{
-				var urlRegionSelector = targetUrlExtractInfo.Region;
-				var formatters = targetUrlExtractInfo.Formatters;
-				var urlPatterns = targetUrlExtractInfo.Patterns;
-
-				var links = urlRegionSelector == null ? page.Selectable.Links().GetValues() : (page.Selectable.SelectList(urlRegionSelector)).Links().GetValues();
-				if (links == null)
-				{
-					return;
-				}
-
-				// check: 仔细考虑是放在前面, 还是在后面做 formatter, 我倾向于在前面. 对targetUrl做formatter则表示Start Url也应该是要符合这个规则的。
-				if (formatters != null && formatters.Count > 0)
-				{
-					List<string> tmp = new List<string>();
-					foreach (string link in links)
-					{
-						var url = new String(link.ToCharArray());
-						foreach (Formatter f in formatters)
-						{
-							url = f.Formate(url);
-						}
-						tmp.Add(url);
-					}
-					links = tmp;
-				}
-
-				List<string> tmpLinks = new List<string>();
-				foreach (var link in links)
-				{
-#if !NET_CORE
-					tmpLinks.Add(HttpUtility.HtmlDecode(HttpUtility.UrlDecode(link)));
-#else
-					tmpLinks.Add(WebUtility.HtmlDecode(WebUtility.UrlDecode(link)));
-#endif
-				}
-				links = tmpLinks;
-
-				if (urlPatterns == null || urlPatterns.Count == 0)
-				{
-					page.AddTargetRequests(links);
-					return;
-				}
-
-				foreach (Regex targetUrlPattern in urlPatterns)
-				{
-					foreach (string link in links)
-					{
-						if (targetUrlPattern.IsMatch(link))
-						{
-							page.AddTargetRequest(new Request(link, page.Request.NextDepth, page.Request.Extras));
-						}
-					}
-				}
 			}
 		}
 

--- a/src/DotnetSpider.Extension/SQL/BaseCreate.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseCreate.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    public class BaseCreate : Generatable<BaseCreate>
+    {
+        protected List<Pair> columns = new List<Pair>();
+        protected internal bool dropIfExists = false;
+
+        public BaseCreate() { }
+
+        public BaseCreate(string table, bool drop=false)
+        {
+            this.table = table;
+            dropIfExists = drop;
+        }
+
+        public override Command toCommand()
+        {
+            if (dropIfExists)
+            {
+                this.statement = ($@"IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'{this.table}') AND type in (N'U'))
+DROP TABLE {this.table}
+");
+            }
+            this.statement += $@"CREATE TABLE {table}({generateColumns()}) ON [PRIMARY]";
+            return new Command(this.statement, this.@params);
+        }
+
+        private string generateColumns()
+        {
+            string statement = "";
+
+            for (int i = 0, updatesSize = columns.Count; i < updatesSize; i++)
+            {
+                Pair pair = columns[i];
+                if (pair is StatementPair)
+                    statement += pair.name;
+                else
+                {
+                    this.@params.Add(pair.value.ToString());
+                    statement += $"[{pair.name}] {pair.value.ToString()}";
+                }
+
+                if (i < updatesSize - 1)
+                {
+                    statement += ",";
+                }
+            }
+
+            return statement;
+        }
+
+        public BaseCreate AddColumn(string column, string typeName, string identityString = null, string size = "", bool nullable = true)
+        {
+            string type = typeName;
+            type = string.IsNullOrEmpty(size) ? type : $"{type}({size})";
+            type = string.IsNullOrEmpty(identityString) ? type : $"{type} {identityString}";
+            type = nullable ? $"{type} NULL" : $"{type} NOT NULL";
+            columns.Add(new Pair(column, type));
+            return this;
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/BaseDelete.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseDelete.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    public class BaseDelete : Generatable<BaseDelete>
+    {
+        public BaseDelete() { }
+
+        public BaseDelete(string table)
+        {
+            this.table = table;
+        }
+
+        public override Command toCommand()
+        {
+            this.statement = string.Format("DELETE FROM {0}{1}", table, generateWhereBlock());
+            return new Command(this.statement, this.@params);
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/BaseInsert.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseInsert.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    public class BaseInsert : Generatable<BaseInsert>
+    {
+        protected List<Pair> pairs = new List<Pair>();
+
+        public BaseInsert()
+        { }
+
+        public BaseInsert(string table)
+        {
+            this.table = table;
+        }
+
+        public BaseInsert Values(string column, object value)
+        {
+            if (value != null)
+                pairs.Add(new Pair(column, value));
+            return this;
+        }
+
+        public BaseInsert Values(Boolean ifTrue, string column, object value)
+        {
+            if (ifTrue)
+                Values(column, value);
+            return this;
+        }
+
+        public BaseInsert Values(Dictionary<string, object> map)
+        {
+            foreach (KeyValuePair<string, object> entry in map.AsEnumerable())
+                Values(entry.Key, entry.Value);
+            return this;
+        }
+
+        public override Command toCommand()
+        {
+            this.statement = string.Format("INSERT INTO {0}({1}) VALUES ({2})", table, joinNames(pairs), joinQuestionMarks(pairs));
+            this.@params = getValues(pairs);
+
+            return new Command(statement, @params);
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/BaseSQL.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseSQL.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    /// <summary>
+    /// 生成 Command 的帮助类
+    /// </summary>
+    public class BaseSQL<S, U, I, D, C> 
+        where S : BaseSelect, new()
+        where U : BaseUpdate, new()
+        where I : BaseInsert, new()
+        where D : BaseDelete, new()
+        where C : BaseCreate, new()
+    {
+        public static S SELECT(string columns)
+        {
+            return new S() { columns = columns };
+        }
+
+        public static U UPDATE(string table)
+        {
+            return new U() { table = table };
+        }
+
+        public static I INSERT(string table)
+        {
+            return new I() { table = table };
+        }
+
+        public static D DELETE(string table)
+        {
+            return new D() { table = table };
+        }
+
+        public static C CreateTable(string table, bool drop)
+        {
+            return new C() { table = table, dropIfExists = drop };
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/BaseSelect.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseSelect.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    /// <summary>
+    /// 用于生成 select 语句的帮助类
+    /// </summary>
+    public class BaseSelect : Generatable<BaseSelect>
+    {
+
+        protected internal string columns;
+
+        protected internal string from;
+
+        protected internal string orderBy;
+
+        protected internal string groupBy;
+
+        public BaseSelect()
+        { }
+
+        public BaseSelect(string columns)
+        {
+            this.columns = columns;
+        }
+
+        public BaseSelect From(string from)
+        {
+            this.from = from;
+            return this;
+        }
+
+        public BaseSelect OrderBy(string orderBy)
+        {
+            this.orderBy = orderBy;
+            return this;
+        }
+
+        public BaseSelect GroupBy(string groupBy)
+        {
+            this.groupBy = groupBy;
+            return this;
+        }
+
+
+        public override Command toCommand()
+        {
+            this.statement = string.Format("SELECT {0} FROM {1} ", this.columns, this.from);
+
+            this.statement += generateWhereBlock();
+
+            if (!isEmpty(this.groupBy))
+                this.statement += " GROUP BY " + this.groupBy;
+
+            if (!isEmpty(this.orderBy))
+                this.statement += " ORDER BY " + this.orderBy;
+
+            return new Command(this.statement, this.@params);
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/BaseUpdate.cs
+++ b/src/DotnetSpider.Extension/SQL/BaseUpdate.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    /**
+     * 用于生成 update 语句的帮助类
+     */
+    public class BaseUpdate : Generatable<BaseUpdate>
+    {
+
+        protected List<Pair> updates = new List<Pair>();
+
+        public BaseUpdate() { }
+
+        public BaseUpdate(string table)
+        {
+            this.table = table;
+        }
+
+        public override Command toCommand()
+        {
+            this.statement = string.Format("UPDATE {0} set {1} {2}", table, generateSetBlock(), generateWhereBlock());
+
+            return new Command(this.statement, this.@params);
+        }
+
+        private string generateSetBlock()
+        {
+            string statement = "";
+
+            for (int i = 0, updatesSize = updates.Count; i < updatesSize; i++)
+            {
+                Pair pair = updates[i];
+                if (pair is StatementPair)
+                    statement += pair.name;
+                else
+                {
+                    this.@params.Add(pair.value.ToString());
+                    statement += pair.name + "=?";
+                }
+
+                if (i < updatesSize - 1)
+                {
+                    statement += ",";
+                }
+            }
+
+            return statement;
+        }
+
+        public BaseUpdate Set(Boolean exp, string column, object value)
+        {
+            if (exp)
+            {
+                this.updates.Add(new Pair(column, value));
+            }
+            return this;
+        }
+
+        public BaseUpdate Set(string column, object value)
+        {
+            this.updates.Add(new Pair(column, value));
+            return this;
+        }
+
+        public BaseUpdate Set(string setStatement)
+        {
+            this.updates.Add(new StatementPair(setStatement));
+            return this;
+        }
+
+        public BaseUpdate Set(Boolean exp, string setStatement)
+        {
+            if (exp)
+                this.updates.Add(new StatementPair(setStatement));
+            return this;
+        }
+
+        public BaseUpdate SetIfNotNull(string column, object value)
+        {
+            return Set(value != null, column, value);
+        }
+
+        public BaseUpdate SetIfNotEmpty(string column, object value)
+        {
+            return Set(!isEmpty(value), column, value);
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/Command.cs
+++ b/src/DotnetSpider.Extension/SQL/Command.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    /// <summary>
+    /// 表示 SQL 命令的类。其中包含 SQL 语句和参数两个部分。参数的值要和 SQL 语句中的问号一一对应。 
+    /// </summary>
+    public class Command
+    {
+        private string statement;
+
+        private List<string> @params;
+
+        private List<string> paramTypes;
+
+        /// <summary>
+        /// 缺省构造函数
+        /// </summary>
+        public Command()
+        {
+
+        }
+
+        /// <summary>
+        /// 构造函数
+        /// </summary>
+        /// <param name="statement">SQL 语句</param>
+        /// <param name="params">参数</param>
+        public Command(string statement, List<string> @params)
+        {
+            this.statement = statement;
+            this.@params = @params;
+        }
+
+        public Command(string statement, List<string> @params, List<string> paramTypes)
+        {
+            this.statement = statement;
+            this.@params = @params;
+            this.paramTypes = paramTypes;
+        }
+
+        public List<string> getParamTypes()
+        {
+            return paramTypes;
+        }
+
+        public void setParamTypes(List<string> paramTypes)
+        {
+            this.paramTypes = paramTypes;
+        }
+
+        /// <summary>
+        /// 获得 SQL 语句
+        /// </summary>
+        /// <returns>SQL 语句</returns>
+        public string getStatement()
+        {
+            return statement;
+        }
+
+        /// <summary>
+        /// 设置 SQL 语句
+        /// </summary>
+        /// <param name="statement">SQL 语句</param>
+        public void setStatement(string statement)
+        {
+            this.statement = statement;
+        }
+
+        /// <summary>
+        /// 获得参数
+        /// </summary>
+        /// <returns>参数</returns>
+        public List<string> getParams()
+        {
+            return @params;
+        }
+
+        /// <summary>
+        /// 设置参数
+        /// </summary>
+        /// <param name="params">参数</param>
+        public void setParams(List<string> @params)
+        {
+            this.@params = @params;
+        }
+
+        public override string ToString()
+        {
+            return "Command{" +
+                    "statement='" + statement + '\'' +
+                    ", params=" + @params +
+                    '}';
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/Generatable.cs
+++ b/src/DotnetSpider.Extension/SQL/Generatable.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    public abstract class Generatable<T> where T : Generatable<T>
+    {
+
+        protected internal string table;
+
+        protected internal string statement;
+
+        protected internal List<string> @params = new List<string>();
+
+        protected internal List<Pair> conditions = new List<Pair>();
+
+        public abstract Command toCommand();
+
+        public string joinNames(List<Pair> pairs)
+        {
+            if (pairs.Count == 0)
+                return "";
+            else
+            {
+                string result = "";
+                foreach (Pair pair in pairs)
+                {
+                    result += pair.name + ",";
+                }
+                result = result.Substring(0, result.Length - 1);
+                return result;
+            }
+        }
+
+        public string joinValues(List<Pair> pairs)
+        {
+            if (pairs.Count == 0)
+                return "";
+            else
+            {
+                string result = "";
+                foreach (Pair pair in pairs)
+                {
+                    result += pair.value + ",";
+                }
+                result = result.Substring(0, result.Length - 1);
+                return result;
+            }
+        }
+
+
+        internal static Boolean isEmpty(object obj)
+        {
+            if (obj == null)
+                return true;
+
+            string str = obj.ToString();
+            return str.Length == 0 || str.Trim().Length == 0;
+        }
+
+        protected string joinQuestionMarks(List<Pair> pairs)
+        {
+            StringBuilder s = new StringBuilder();
+            for (int size = pairs.Count, i = 0; i < size; i++)
+                s.Append('?').Append(i == size - 1 ? "" : ",");
+            return s.ToString();
+        }
+
+        protected List<string> getValues(List<Pair> pairs)
+        {
+            if (pairs.Count == 0)
+                return new List<string>();
+
+            List<string> result = new List<string>();
+            foreach (Pair pair in pairs)
+                result.Add(pair.value.ToString());
+
+            return result;
+        }
+
+        public T Where(string statement)
+        {
+            if (this is BaseInsert)
+                throw new Exception("cannot use 'where' block in Insert");
+            this.conditions.Add(new StatementPair(statement));
+            return (T)this;
+        }
+
+        public T Where(string column, object value)
+        {
+            if (this is BaseInsert)
+            {
+                throw new Exception("cannot use 'where' block in Insert");
+            }
+            this.conditions.Add(new Pair(column, value));
+            return (T)this;
+        }
+
+        public T Where(Boolean exp, string statement)
+        {
+            if (this is BaseInsert)
+                throw new Exception("cannot use 'where' block in Insert");
+            if (exp)
+                this.conditions.Add(new StatementPair(statement));
+            return (T)this;
+        }
+
+        public T Where(Boolean exp, string column, object value)
+        {
+            if (this is BaseInsert)
+                throw new Exception("cannot use 'where' block in Insert");
+            if (exp)
+                this.conditions.Add(new Pair(column, value));
+            return (T)this;
+        }
+
+        public T And(string statement)
+        {
+            this.conditions.Add(new StatementPair(Pref.AND, statement));
+            return (T)this;
+        }
+
+        public T And(string column, object value)
+        {
+            this.conditions.Add(new Pair(Pref.AND, column, value));
+            return (T)this;
+        }
+
+        public T And(Boolean exp, string statement)
+        {
+            if (exp)
+            {
+                this.conditions.Add(new StatementPair(Pref.AND, statement));
+            }
+            return (T)this;
+        }
+
+        public T And(Boolean exp, string column, object value)
+        {
+            if (exp)
+            {
+                this.conditions.Add(new Pair(Pref.AND, column, value));
+            }
+            return (T)this;
+        }
+
+        public T AndIfNotEmpty(string column, object value)
+        {
+            return And(!isEmpty(value), column, value);
+        }
+
+        public T Or(string statement)
+        {
+            this.conditions.Add(new StatementPair(Pref.OR, statement));
+            return (T)this;
+        }
+
+        public T Or(string column, object value)
+        {
+            this.conditions.Add(new Pair(Pref.OR, column, value));
+            return (T)this;
+        }
+
+        public T Or(Boolean exp, string statement)
+        {
+            if (exp)
+            {
+                this.conditions.Add(new StatementPair(Pref.OR, statement));
+            }
+            return (T)this;
+        }
+
+        public T Or(Boolean exp, string column, object value)
+        {
+            if (exp)
+                this.conditions.Add(new Pair(Pref.OR, column, value));
+            return (T)this;
+        }
+
+        public T OrIfNotEmpty(string column, object value)
+        {
+            return Or(!isEmpty(value), column, value);
+        }
+
+        public T Append(string statement)
+        {
+            this.conditions.Add(new StatementPair(statement));
+            return (T)this;
+        }
+
+        public T Append(string column, object value)
+        {
+            this.conditions.Add(new Pair(column, value));
+            return (T)this;
+        }
+
+        public T Append(Boolean exp, string statement)
+        {
+            if (exp)
+                this.conditions.Add(new StatementPair(statement));
+            return (T)this;
+        }
+
+        public T Append(Boolean exp, string column, object value)
+        {
+            if (exp)
+                this.conditions.Add(new Pair(column, value));
+            return (T)this;
+        }
+
+        protected string generateWhereBlock()
+        {
+            string where = "";
+
+            if (this.conditions.Count > 0)
+            {
+                where = "WHERE ";
+
+                for (int i = 0, conditionsSize = conditions.Count; i < conditionsSize; i++)
+                {
+                    Pair condition = conditions[i];
+                    where = processCondition(i, where, condition);
+                }
+
+            }
+
+            return " " + where;
+        }
+
+        private string processCondition(int index, string where, Pair condition)
+        {
+
+            where = where.Trim();
+
+            // 第一个条件不能加 and 和 or 前缀
+            if (index > 0 && !where.EndsWith("("))
+            {
+                if (condition.pref == Pref.AND)
+                    where += " AND ";
+                else if (condition.pref == Pref.OR)
+                    where += " OR ";
+            }
+
+            where += " ";
+
+            if (condition is StatementPair)
+            {       // 不带参数的条件
+                where += condition.name;
+
+            }
+            else if (condition.value is List<string>)
+            {   // 参数为 List 的条件（即 in 条件）
+                string marks = "(";
+
+                foreach (string o in (List<string>)condition.value)
+                {
+                    marks += "?,";
+                    this.@params.Add(o);
+                }
+
+                if (marks.EndsWith(","))
+                {
+                    marks = marks.Substring(0, marks.Length - 1);
+                }
+                marks += ")";                                 // marks = "(?,?,?,...,?)"
+
+                where += condition.name.Replace("?", marks);  // "A in ?" -> "A in (?,?,?)"
+
+            }
+            else
+            {
+                where += condition.name;
+                this.@params.Add(condition.value.ToString());
+            }
+
+            return where;
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/Create.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/Create.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class Create : BaseCreate
+    {
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/Delete.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/Delete.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class Delete : BaseDelete
+    {
+
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/Insert.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/Insert.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class Insert : BaseInsert
+    {
+        public override Command toCommand()
+        {
+            this.statement = string.Format("INSERT INTO {0}({1}) VALUES ({2})", table, joinNames(pairs), joinValues(pairs));
+            this.@params = getValues(pairs);
+
+            return new Command(statement, @params);
+        }
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/SQL.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/SQL.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class SQL : BaseSQL<Select, Update, Insert, Delete, Create>
+    {
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/Select.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/Select.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class Select : BaseSelect
+    {
+
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/MSSql/Update.cs
+++ b/src/DotnetSpider.Extension/SQL/MSSql/Update.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL.MSSql
+{
+    public class Update : BaseUpdate
+    {
+
+    }
+}

--- a/src/DotnetSpider.Extension/SQL/Pair.cs
+++ b/src/DotnetSpider.Extension/SQL/Pair.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DotnetSpider.Extension.SQL
+{
+    public class Pair
+    {
+
+        public Pref pref { get; set; }
+
+        public string name { get; set; }
+
+        public object value { get; set; }
+
+        public Pair(string name, object value)
+        {
+            this.name = name;
+            this.value = value;
+        }
+
+        public Pair(Pref pref, string name, object value)
+        {
+            this.pref = pref;
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    public class StatementPair : Pair
+    {
+
+        public StatementPair(string statement)
+            : base(statement, null)
+        {
+
+        }
+
+        public StatementPair(Pref pref, string statement)
+            : base(pref, statement, null)
+        {
+
+        }
+    }
+
+    public enum Pref
+    {
+        AND, OR
+    }
+
+
+}

--- a/src/DotnetSpider.Extension/netfx45/DotnetSpider.Extension.csproj
+++ b/src/DotnetSpider.Extension/netfx45/DotnetSpider.Extension.csproj
@@ -125,6 +125,10 @@
       <HintPath>..\..\..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="WebDriver.Support, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Selenium.Support.2.53.1\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\DotnetSpider.Core\netfx45\DotnetSpider.Core.csproj">
@@ -193,6 +197,9 @@
     </Compile>
     <Compile Include="..\Model\Attribute\BaseSelector.cs">
       <Link>Model\Attribute\BaseSelector.cs</Link>
+    </Compile>
+    <Compile Include="..\Model\Attribute\TargetUrl.cs">
+      <Link>Model\Attribute\TargetUrl.cs</Link>
     </Compile>
     <Compile Include="..\Model\Attribute\Download.cs">
       <Link>Model\Attribute\Download.cs</Link>

--- a/src/DotnetSpider.Extension/netfx45/DotnetSpider.Extension.csproj
+++ b/src/DotnetSpider.Extension/netfx45/DotnetSpider.Extension.csproj
@@ -300,6 +300,51 @@
     <Compile Include="..\ORM\TableSuffix.cs">
       <Link>ORM\TableSuffix.cs</Link>
     </Compile>
+    <Compile Include="..\SQL\MSSql\Create.cs">
+      <Link>SQL\MSSql\Create.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\MSSql\Delete.cs">
+      <Link>SQL\MSSql\Delete.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\MSSql\Insert.cs">
+      <Link>SQL\MSSql\Insert.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\MSSql\Select.cs">
+      <Link>SQL\MSSql\Select.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\MSSql\SQL.cs">
+      <Link>SQL\MSSql\SQL.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\MSSql\Update.cs">
+      <Link>SQL\MSSql\Update.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseCreate.cs">
+      <Link>SQL\BaseCreate.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseDelete.cs">
+      <Link>SQL\BaseDelete.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseInsert.cs">
+      <Link>SQL\BaseInsert.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseSelect.cs">
+      <Link>SQL\BaseSelect.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseSQL.cs">
+      <Link>SQL\BaseSQL.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\BaseUpdate.cs">
+      <Link>SQL\BaseUpdate.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\Command.cs">
+      <Link>SQL\Command.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\Generatable.cs">
+      <Link>SQL\Generatable.cs</Link>
+    </Compile>
+    <Compile Include="..\SQL\Pair.cs">
+      <Link>SQL\Pair.cs</Link>
+    </Compile>
     <Compile Include="..\Pipeline\BaseEntityDbPipeline.cs">
       <Link>Pipeline\BaseEntityDbPipeline.cs</Link>
     </Compile>
@@ -329,6 +374,9 @@
     </Compile>
     <Compile Include="..\Pipeline\MongoDbEntityPipeline.cs">
       <Link>Pipeline\MongoDbEntityPipeline.cs</Link>
+    </Compile>
+    <Compile Include="..\Pipeline\MSSqlEntityPipeline.cs">
+      <Link>Pipeline\MSSqlEntityPipeline.cs</Link>
     </Compile>
     <Compile Include="..\Pipeline\MultiPagePipeline.cs">
       <Link>Pipeline\MultiPagePipeline.cs</Link>

--- a/src/DotnetSpider.Extension/netfx45/packages.config
+++ b/src/DotnetSpider.Extension/netfx45/packages.config
@@ -14,6 +14,7 @@
   <package id="MySql.Data" version="6.9.9" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NLog" version="4.3.7" targetFramework="net45" />
+  <package id="Selenium.Support" version="2.53.1" targetFramework="net45" />
   <package id="Selenium.WebDriver" version="2.53.1" targetFramework="net45" />
   <package id="StackExchange.Redis" version="1.1.603" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net45" />

--- a/src/DotnetSpider.Extension/project.json
+++ b/src/DotnetSpider.Extension/project.json
@@ -26,8 +26,7 @@
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0",
     "MailKit": "1.4.1",
-    "DotnetSpider.Redial": "0.0.9"
-  },
+    "DotnetSpider.Redial": "0.0.9"  },
   "frameworks": {
     "netcoreapp1.0": {
       "imports": "portable-net45+win8+dnxcore50",

--- a/src/DotnetSpider.Sample/GSXSpider.cs
+++ b/src/DotnetSpider.Sample/GSXSpider.cs
@@ -65,7 +65,7 @@ namespace DotnetSpider.Sample
             context.SetDownloader(new WebDriverDownloader(Browser.Chrome, 300));
             context.SetThreadNum(1);
             //context.AddEntityPipeline(new MySqlEntityPipeline("Database='gsx';Data Source=localhost;User ID=root;Password=pass@word1;Port=4040")
-            context.AddEntityPipeline(new MSSqlEntityPipeline("Database='YCOMS';Data Source=.;Integrated Security=SSPI;")
+            context.AddEntityPipeline(new MSSqlEntityPipeline("Database='GSXData';Data Source=.;Integrated Security=SSPI;")
             //{ Mode = PipelineMode.Update }
             );
             return context;
@@ -159,6 +159,10 @@ namespace DotnetSpider.Sample
             [PropertySelector(Expression = @"//div[@id=""main""]//a[img[@class=""thumbnail""]]/@href")]
             [RegexMatchFormatter(Pattern = @"\d{2,}")]
             public string 学生ID { get; set; }
+
+            [StoredAs("教师ID", DataType.String, 20)]
+            [PropertySelector(Expression = @"教师ID", Type = SelectorType.Enviroment)]
+            public string 教师ID { get; set; }
 
             [StoredAs("实际收入", DataType.String, 10)]
             [PropertySelector(Expression = @"//div[@id=""main""]//strong[1]")]

--- a/src/DotnetSpider.Sample/GSXSpider.cs
+++ b/src/DotnetSpider.Sample/GSXSpider.cs
@@ -64,7 +64,8 @@ namespace DotnetSpider.Sample
             context.AddEntityType(typeof(主页)).AddEntityType(typeof(订单列表项)).AddEntityType(typeof(订单));
             context.SetDownloader(new WebDriverDownloader(Browser.Chrome, 300));
             context.SetThreadNum(1);
-            context.AddEntityPipeline(new MySqlEntityPipeline("Database='gsx';Data Source=localhost;User ID=root;Password=pass@word1;Port=4040")
+            //context.AddEntityPipeline(new MySqlEntityPipeline("Database='gsx';Data Source=localhost;User ID=root;Password=pass@word1;Port=4040")
+            context.AddEntityPipeline(new MSSqlEntityPipeline("Database='YCOMS';Data Source=.;Integrated Security=SSPI;")
             //{ Mode = PipelineMode.Update }
             );
             return context;
@@ -76,6 +77,12 @@ namespace DotnetSpider.Sample
             [TargetUrl]
             [PropertySelector(Expression = "//a[@ui-sref=\"jigou.orders\"]")]
             public string 订单页面链接 { get; set; }
+
+            public static Func<IWebDriver, IWebElement> UntilCondition()
+            {
+                return ExpectedConditions.ElementExists(By.XPath("//a[@ui-sref=\"jigou.orders\"]"));
+            }
+
         }
 
         [TargetUrl(UrlPattern = @"http://i\.genshuixue\.com/main(\?tick=[0-9]*)*#/orders//$", KeepOrigin = true)]

--- a/src/DotnetSpider.Sample/GSXSpider.cs
+++ b/src/DotnetSpider.Sample/GSXSpider.cs
@@ -57,13 +57,16 @@ namespace DotnetSpider.Sample
                 },
                 Accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
                 UserAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
-            }) { CookieInterceptor = cookieThief };
+            })
+            { CookieInterceptor = cookieThief };
             context.SetIdentity("gsx 订单/store test " + DateTime.Now.ToString("yyyy-MM-dd HHmmss"));
             context.AddStartUrl("http://i.genshuixue.com/main");
             context.AddEntityType(typeof(主页)).AddEntityType(typeof(订单列表项)).AddEntityType(typeof(订单));
             context.SetDownloader(new WebDriverDownloader(Browser.Chrome, 300));
             context.SetThreadNum(1);
-            context.AddEntityPipeline(new MySqlEntityPipeline("Database='gsx';Data Source=localhost;User ID=root;Password=pass@word1;Port=3306"));
+            context.AddEntityPipeline(new MySqlEntityPipeline("Database='gsx';Data Source=localhost;User ID=root;Password=pass@word1;Port=4040")
+            //{ Mode = PipelineMode.Update }
+            );
             return context;
         }
 
@@ -98,6 +101,7 @@ namespace DotnetSpider.Sample
         /// </summary>
         [TargetUrl(UrlPattern = @"http://i\.genshuixue\.com/teacher/order\.do\?tid=\d+&purchaseId=\d+", KeepOrigin = true)]
         [Schema("GSX", "订单", TableSuffix.Today)]
+        [Indexes(Primary = "订单编号")]
         public class 订单 : ISpiderEntity
         {
             [StoredAs("订单编号", DataType.String, 20)]

--- a/src/DotnetSpider.Sample/GSXSpider.cs
+++ b/src/DotnetSpider.Sample/GSXSpider.cs
@@ -1,0 +1,116 @@
+﻿#if !NET_CORE
+using DotnetSpider.Core.Selector;
+using DotnetSpider.Extension;
+using DotnetSpider.Extension.Downloader;
+using DotnetSpider.Extension.Downloader.WebDriver;
+using DotnetSpider.Extension.Model;
+using DotnetSpider.Extension.Model.Attribute;
+using DotnetSpider.Extension.ORM;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+using System.Collections.Generic;
+
+namespace DotnetSpider.Sample
+{
+    /// <summary>
+    /// No pipelines, test for TargetUrl, PropertySelector and UntilCondition.
+    /// </summary>
+    public class GSXSpider : EntitySpiderBuilder
+    {
+        protected override EntitySpider GetEntitySpider()
+        {
+            var cookieThief = new LoginCookieInterceptor()
+            {
+                Url = "https://i.genshuixue.com/login",
+                UserSelector = new Selector
+                {
+                    Type = SelectorType.XPath,
+                    Expression = @"//form[@id=""loginForm""]//input[@name=""username""]"
+                },
+                User = "someuser",
+                PassSelector = new Selector
+                {
+                    Type = SelectorType.XPath,
+                    Expression = @"//form[@id=""loginForm""]/div[@class=""form-group form-password""]//input"
+                },
+                Pass = "somepwd",
+                SubmitSelector = new Selector
+                {
+                    Type = SelectorType.XPath,
+                    Expression = @"//form[@id=""loginForm""]//button[@class=""btn btn-info btn-block""]"
+                }
+            };
+
+            EntitySpider context = new EntitySpider(new Core.Site
+            {
+                Headers = new Dictionary<string, string>
+                {
+                    { "Cache-Control","max-age=0"},
+                    { "Host", "i.genshuixue.com" },
+                    { "Connection", "keep-alive"},
+                    { "Upgrade-Insecure-Requests", "1" },
+                    { "Accept-Encoding", "gzip, deflate, sdch"},
+                    { "Accept-Language", "zh-CN,zh;q=0.8"}
+                },
+                Accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                UserAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            }) { CookieInterceptor = cookieThief };
+            context.SetIdentity("gsx 订单/store test " + DateTime.Now.ToString("yyyy-MM-dd HHmmss"));
+            context.AddStartUrl("http://i.genshuixue.com/main");
+            context.AddEntityType(typeof(主页)).AddEntityType(typeof(订单列表项));
+            context.SetDownloader(new WebDriverDownloader(Browser.Chrome, 300));
+            context.SetThreadNum(4);
+            return context;
+        }
+
+        [TargetUrl(UrlPattern = @"http://i\.genshuixue\.com/main[^/]*$", KeepOrigin = true)]
+        public class 主页 : ISpiderEntity
+        {
+            [TargetUrl]
+            //[PropertySelector(Expression = @"//div[@id=""sidebar""]//li[3]/ul/li[3]")]
+            [PropertySelector(Expression = "//a[@ui-sref=\"jigou.orders\"]")]
+            public string 订单页面链接 { get; set; }
+        }
+
+        [TargetUrl(UrlPattern = @"http://i\.genshuixue\.com/main(\?tick=[0-9]*)*#/orders//$", KeepOrigin = true)]
+        [EntitySelector(Expression = "//div[@id=\"order-wrapper\"]//div[@class=\"orders-table\"]/div[@class=\"table-body ng-scope\"]")]
+        public class 订单列表项 : ISpiderEntity
+        {
+            [PropertySelector(Expression = ".//a[@class=\"teacher-name\"]/@href", Pattern = "^.*/([0-9]*)", ReplaceString = "$1")]
+            public string 教师ID { get; set; }
+
+            [TargetUrl(OtherPropertiesAsExtras = new[] { "教师ID" })]
+            [PropertySelector(Expression = @".//div[@class=""orders-viewdetail""]")]
+            public string 详情页面链接 { get; set; }
+
+            public static Func<IWebDriver, IWebElement> UntilCondition()
+            {
+                return ExpectedConditions.ElementExists(By.XPath("//div[@id=\"order-wrapper\"]//div[@class=\"orders-table\"]/div[@class=\"table-body ng-scope\"]"));
+            }
+        }
+
+        /// <summary>
+        /// Not finished yet.
+        /// </summary>
+        [TargetUrl(UrlPattern = "http://www.genshuixue.com/order/teacherOrderDetail?purchase_id=*")]
+        [Schema("GSX", "订单", TableSuffix.Today)]
+        public class 订单 : ISpiderEntity
+        {
+            public string 订单编号 { get; set; }
+
+            public int 总时长 { get; set; }
+
+            public int 已完成 { get; set; }
+
+            public int 可约课 { get; set; }
+
+            public decimal 总价 { get; set; }
+
+            public decimal 单价 { get; set; }
+
+
+        }
+    }
+}
+#endif

--- a/src/DotnetSpider.Sample/GSXSpider.cs
+++ b/src/DotnetSpider.Sample/GSXSpider.cs
@@ -5,6 +5,7 @@ using DotnetSpider.Extension.Downloader;
 using DotnetSpider.Extension.Downloader.WebDriver;
 using DotnetSpider.Extension.Model;
 using DotnetSpider.Extension.Model.Attribute;
+using DotnetSpider.Extension.Model.Formatter;
 using DotnetSpider.Extension.ORM;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
@@ -68,7 +69,6 @@ namespace DotnetSpider.Sample
         public class 主页 : ISpiderEntity
         {
             [TargetUrl]
-            //[PropertySelector(Expression = @"//div[@id=""sidebar""]//li[3]/ul/li[3]")]
             [PropertySelector(Expression = "//a[@ui-sref=\"jigou.orders\"]")]
             public string 订单页面链接 { get; set; }
         }
@@ -77,7 +77,8 @@ namespace DotnetSpider.Sample
         [EntitySelector(Expression = "//div[@id=\"order-wrapper\"]//div[@class=\"orders-table\"]/div[@class=\"table-body ng-scope\"]")]
         public class 订单列表项 : ISpiderEntity
         {
-            [PropertySelector(Expression = ".//a[@class=\"teacher-name\"]/@href", Pattern = "^.*/([0-9]*)", ReplaceString = "$1")]
+            [PropertySelector(Expression = ".//a[@class=\"teacher-name\"]/@href")]
+            [RegexMatchFormatter(Pattern = @"[\d]+")]
             public string 教师ID { get; set; }
 
             [TargetUrl(OtherPropertiesAsExtras = new[] { "教师ID" })]

--- a/src/DotnetSpider.Sample/Program.cs
+++ b/src/DotnetSpider.Sample/Program.cs
@@ -9,9 +9,12 @@ namespace DotnetSpider.Sample
 		public static void Main(string[] args)
 		{
 			IocExtension.ServiceCollection.AddSingleton<IMonitorService, NLogMonitor>();
-
-			JdSkuSampleSpider spiderBuilder = new JdSkuSampleSpider();
-			spiderBuilder.Run("rerun");
+#if NET_CORE
+            JdSkuSampleSpider spiderBuilder = new JdSkuSampleSpider();
+#else
+            GSXSpider spiderBuilder = new GSXSpider();
+#endif
+            spiderBuilder.Run("rerun");
 		}
 	}
 }

--- a/src/DotnetSpider.Sample/netfx45/DotnetSpider.Sample.csproj
+++ b/src/DotnetSpider.Sample/netfx45/DotnetSpider.Sample.csproj
@@ -57,6 +57,10 @@
       <HintPath>..\..\..\packages\Selenium.WebDriver.2.53.1\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="WebDriver.Support, Version=2.53.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Selenium.Support.2.53.1\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\BaseUsage.cs">
@@ -85,6 +89,9 @@
     </Compile>
     <Compile Include="..\TestSpider.cs">
       <Link>TestSpider.cs</Link>
+    </Compile>
+    <Compile Include="..\GSXSpider.cs">
+      <Link>GSXSpider.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
其实改动不大，你用Split看可能比较适应。不过Github的文本比较有问题，好多相同的内容也被判断成不同。我建议你把我的代码都下载了然后在本地用beyondcompare之类的来比对。反正我这里把需要说明的大概说一下：
BloomFilter，原来的代码一概没动，增加一个CrossPlatformUtil类，后面会提到；
ExtractLinks这个方法我移到工具类里面改为public，因为其他地方都要用到。并且增加了一个Selectable的参数。原来这个参数缺失，导致xpath的root始终都是page，我觉得是个bug。
.Core不应有太多引用，我认为你是对的，所以我把原来的List《Cookie》用Dictionary《string, string》代替；
Spider这个类其实主要就是第一个加入了Dictionary《string, MethodInfo》UntilConditionMethods，以及根据CookieInterceptor对Site的cookie赋值。第二个比较大的改动是关于PaserEntityMetaData的：认真说来，改动也不大，但是我觉得为了Type和TypeInfo的不同就把同一个方法分成两个版本有点看着头疼，尤其是要改代码的时候，所以就用到了之前上面增加的CrossPlatform类，把代码尽量合二为一了。另外一个就是新造一个实例方法出来，因为在解析Entity的时候需要获得UntilCondition存入当前Spider的对应属性中。本来按照我的理解是应该抛弃静态方法的，但不想改动太多，这个你来决断。
EntityExtractor 其实就是在Process方法开始时先判断TargetUrl是否吻合。另外就是在ProcessSingle中加入对Pattern和ReplaceString的处理。
有什么问题随时联系我。原有的单元测试都通过了（当然涉及mysql和redis的没有，因为我本地环境不具备条件，而我也没有对这部分有任何改动）。
