### PR TITLE
Fix Bug: Plain Text Content is null

### DIFF
--- a/src/DotnetSpider2.Core/Downloader/HttpClientDownloader.1.cs
+++ b/src/DotnetSpider2.Core/Downloader/HttpClientDownloader.1.cs
@@ -69,7 +69,8 @@ namespace DotnetSpider.Core.Downloader
 				var httpStatusCode = response.StatusCode;
 				request.PutExtra(Request.StatusCode, httpStatusCode);
 				Page page;
-				if (response.Content.Headers.ContentType.MediaType != "text/html")
+				if (response.Content.Headers.ContentType.MediaType != "text/html" 
+                    			&& response.Content.Headers.ContentType.MediaType != "text/plain")
 				{
 					if (!site.DownloadFiles)
 					{


### PR DESCRIPTION
Content-type is text/plain results Page.Content = null , Fix this Bug