### PR TITLE
修复3.1.1分支中TableInfo的重复列检测问题。

### DIFF
--- a/src/DotnetSpider.Extension.Test/Model/TableInfoTest.cs
+++ b/src/DotnetSpider.Extension.Test/Model/TableInfoTest.cs
@@ -17,7 +17,7 @@ namespace DotnetSpider.Extension.Test.Model
 		}
 
 		[Schema]
-		public class DuplicateColumnsWithDifferenPropertiesTable
+		public class DuplicateColumnsWithDifferentPropertiesTable
 		{
 			[Column]
 			public string A { get; set; }
@@ -30,6 +30,7 @@ namespace DotnetSpider.Extension.Test.Model
 		{
 			[Column]
 			public string A { get; set; }
+			public string B { get; set; }
 		}
 
 		[Fact(DisplayName = "TableInfo_DuplicateColumns")]
@@ -42,7 +43,7 @@ namespace DotnetSpider.Extension.Test.Model
 		[Fact(DisplayName = "TableInfo_DuplicateColumnsWithDifferenProperties")]
 		public void DuplicateColumnsWithDifferenProperties()
 		{
-			var e = Assert.Throws<ArgumentException>(() => { var _ = new TableInfo(typeof(DuplicateColumnsWithDifferenPropertiesTable)); });
+			var e = Assert.Throws<ArgumentException>(() => { var _ = new TableInfo(typeof(DuplicateColumnsWithDifferentPropertiesTable)); });
 			Assert.Equal("Column names should not be same", e.Message);
 		}
 

--- a/src/DotnetSpider.Extension.Test/Model/TableInfoTest.cs
+++ b/src/DotnetSpider.Extension.Test/Model/TableInfoTest.cs
@@ -1,0 +1,55 @@
+﻿using DotnetSpider.Extension.Model;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DotnetSpider.Extension.Test.Model
+{
+	public class TableInfoTest
+	{
+		[Schema]
+		public class DuplicateColumnsTable
+		{
+			[Column]
+			public string A { get; set; }
+			[Column("A")]
+			public string B { get; set; }
+		}
+
+		[Schema]
+		public class DuplicateColumnsWithDifferenPropertiesTable
+		{
+			[Column]
+			public string A { get; set; }
+			[Column("A", Length = 2)]
+			public string B { get; set; }
+		}
+
+		[Schema]
+		public class DonotUseAllPropertiesTable
+		{
+			[Column]
+			public string A { get; set; }
+		}
+
+		[Fact(DisplayName = "TableInfo_DuplicateColumns")]
+		public void DuplicateColumns()
+		{
+			var e = Assert.Throws<ArgumentException>(() => { var _ = new TableInfo(typeof(DuplicateColumnsTable)); });
+			Assert.Equal("Column names should not be same", e.Message);
+		}
+
+		[Fact(DisplayName = "TableInfo_DuplicateColumnsWithDifferenProperties")]
+		public void DuplicateColumnsWithDifferenProperties()
+		{
+			var e = Assert.Throws<ArgumentException>(() => { var _ = new TableInfo(typeof(DuplicateColumnsWithDifferenPropertiesTable)); });
+			Assert.Equal("Column names should not be same", e.Message);
+		}
+
+		[Fact(DisplayName = "TableInfo_DonotUseAllProperties")]
+		public void DonotUseAllProperties()
+		{
+			var _ = new TableInfo(typeof(DonotUseAllPropertiesTable));
+		}
+	}
+}

--- a/src/DotnetSpider.Extension/Model/TableInfo.cs
+++ b/src/DotnetSpider.Extension/Model/TableInfo.cs
@@ -38,7 +38,7 @@ namespace DotnetSpider.Extension.Model
 
 			var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
 
-			Columns = new HashSet<Column>();
+			Columns = new HashSet<Column>(new ColumnNameComparer());
 			Primary = new List<Column>();
 			Indexes = new Dictionary<string, List<Column>>();
 			Uniques = new Dictionary<string, List<Column>>();
@@ -63,7 +63,10 @@ namespace DotnetSpider.Extension.Model
 					column.DataType = ConvertDataType(property.PropertyType);
 				}
 
-				Columns.Add(column);
+				if (Columns.Add(column) == false)
+				{
+					throw new ArgumentException("Column names should not be same");
+				}
 
 				var primary = property.GetCustomAttributes(typeof(Primary), true).FirstOrDefault() as Primary;
 				if (primary != null)
@@ -112,11 +115,6 @@ namespace DotnetSpider.Extension.Model
 				}
 			}
 
-			if (Columns.Count != properties.Length)
-			{
-				throw new ArgumentException("Column names should not be same");
-			}
-
 			if (Columns.Count == 0)
 			{
 				throw new ArgumentException("Table should contains at least one column");
@@ -163,6 +161,19 @@ namespace DotnetSpider.Extension.Model
 				{
 					return DataType.String;
 				}
+			}
+		}
+
+		private class ColumnNameComparer : IEqualityComparer<Column>
+		{
+			public bool Equals(Column x, Column y)
+			{
+				return x.Name == y.Name;
+			}
+
+			public int GetHashCode(Column obj)
+			{
+				return obj.GetHashCode();
 			}
 		}
 	}


### PR DESCRIPTION
- 修复TableInfo中不能检测拥有不同属性的同名列的bug。

- 修复TableInfo中对于没有标记Column的属性提示为重复列的bug。

- 增加相关测试用例。