### PR TITLE
fix:System.ArgumentNullException:

### DIFF
--- a/src/DotnetSpider/DataFlow/Parser/DataParser.cs
+++ b/src/DotnetSpider/DataFlow/Parser/DataParser.cs
@@ -43,7 +43,7 @@ namespace DotnetSpider.DataFlow.Parser
 		{
 			_followRequestQueriers.Add(context =>
 			{
-				var requests = context.Selectable.SelectList(selector)
+				var requests = context.Selectable.SelectList(selector)?
 					.Where(x => x != null)
 					.SelectMany(x => x.Links())
 					.Select(x =>


### PR DESCRIPTION
using System.Linq;
public static class Enumerable

// 异常:
//   T:System.ArgumentNullException:
//     source or predicate is null.
public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate);